### PR TITLE
Fix failing GitHub Actions for GitHub Pages site

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'docs'
 


### PR DESCRIPTION
The GitHub actions for the GitHub pages site is failing. Fix it. 

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/KBW8ndWpBhkz/implementations/bqngcKJpgFmt)