### PR TITLE
Refactor lander content from HTML to Markdown/YAML for easier editing

### DIFF
--- a/docs/build.rb
+++ b/docs/build.rb
@@ -1,0 +1,1191 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Lander Build Script
+# Renders docs/index.html from YAML configuration and Markdown content files
+#
+# Usage: ruby docs/build.rb
+#
+# This script reads:
+#   - docs/content/lander.yml (page structure and metadata)
+#   - docs/content/sections/*.md (section content in markdown)
+#
+# And generates:
+#   - docs/index.html
+#
+# Note: For complex sections (pricing tables, services, add-ons),
+# this script generates the basic structure. Review the output for accuracy.
+
+require 'yaml'
+require 'erb'
+require 'cgi'
+
+class LanderBuilder
+  DOCS_DIR = File.expand_path('..', __FILE__)
+  CONTENT_DIR = File.join(DOCS_DIR, 'content')
+  CONFIG_FILE = File.join(CONTENT_DIR, 'lander.yml')
+  OUTPUT_FILE = File.join(DOCS_DIR, 'index.html')
+
+  def initialize
+    @config = YAML.load_file(CONFIG_FILE)
+  end
+
+  def build
+    html = render_template
+    File.write(OUTPUT_FILE, html)
+    puts "Built #{OUTPUT_FILE}"
+  end
+
+  private
+
+  def render_template
+    <<~HTML
+      <!DOCTYPE html>
+      <html lang="en" class="theme-light">
+
+      <head>
+        #{render_head}
+      </head>
+
+      <body>
+        <div class="background-gradient"></div>
+        <div class="page-container">
+          #{render_header}
+          <main>
+            #{render_sections}
+          </main>
+          #{render_footer}
+        </div>
+      </body>
+
+      </html>
+    HTML
+  end
+
+  def render_head
+    meta = @config['meta']
+    <<~HTML.strip
+      <meta charset="utf-8" />
+        <title>#{h meta['title']}</title>
+        <meta content="#{h meta['description']}" name="description" />
+        <meta content="width=device-width, initial-scale=1" name="viewport" />
+
+        <!-- Open Graph -->
+        <meta property="og:type" content="#{h meta.dig('og', 'type')}" />
+        <meta property="og:site_name" content="#{h meta.dig('og', 'site_name')}" />
+        <meta property="og:locale" content="#{h meta.dig('og', 'locale')}" />
+        <meta property="og:title" content="#{h meta.dig('og', 'title')}" />
+        <meta property="og:description" content="#{h meta.dig('og', 'description')}" />
+        <meta property="og:url" content="#{h meta.dig('og', 'url')}" />
+        <meta name="twitter:site" content="#{h meta.dig('twitter', 'site')}" />
+        <meta name="twitter:card" content="#{h meta.dig('twitter', 'card')}" />
+        <meta name="twitter:title" content="#{h meta.dig('twitter', 'title')}" />
+        <meta name="twitter:description" content="#{h meta.dig('twitter', 'description')}" />
+
+        <!-- Favicon and icons -->
+        <link rel="icon" href="#{h meta['favicon']}" sizes="32x32" />
+        <link rel="apple-touch-icon" href="#{h meta['favicon']}" />
+
+        <!-- Preload fonts -->
+        <link rel="preload" href="fonts/InterVariable.woff2" as="font" type="font/woff2" crossorigin />
+
+        <!-- Styles -->
+        <link href="vendor/font-awesome-6.7.2/css/all.min.css" rel="stylesheet" />
+        <link href="css/index.css" rel="stylesheet" type="text/css" />
+        <link href="css/pricing.css" rel="stylesheet" type="text/css" />
+        <link href="css/tablet.css" rel="stylesheet" type="text/css" />
+        <link href="css/mobile.css" rel="stylesheet" type="text/css" />
+        <script src="js/main.js" type="text/javascript" defer></script>
+    HTML
+  end
+
+  def render_header
+    brand = @config['brand']
+    nav = @config['navigation']
+
+    nav_links = nav['links'].map do |link|
+      %(<a href="#{h link['url']}" class="nav-link">#{h link['text']}</a>)
+    end.join("\n        ")
+
+    social_buttons = nav['social'].map do |social|
+      %(<a href="#{h social['url']}" class="button ghost compact hide-on-mobile">\n          <div class="#{h social['icon']} icon l"></div>\n        </a>)
+    end.join("\n        ")
+
+    <<~HTML
+      <header class="nav-container">
+            <a href="/" class="nav-brand" style="display: flex; align-items: center; gap: 8px;">
+              <img src="#{h brand['logo']}" alt="#{h brand['name']}" style="height: 32px; width: 32px;" />
+              <span style="font-size: 1.25rem; font-weight: 600;">#{h brand['name']}</span>
+            </a>
+            <nav role="navigation" class="nav-menu" data-navigation>
+              #{nav_links}
+              <div class="button-group stacked margin-top-l mobile-only">
+                <a href="#{h nav.dig('cta', 'sign_in', 'url')}" class="button tertiary">#{h nav.dig('cta', 'sign_in', 'text')}</a>
+                <a href="#{h nav.dig('cta', 'primary', 'url')}" class="button primary">#{h nav.dig('cta', 'primary', 'text')}</a>
+              </div>
+            </nav>
+            <div class="button-group">
+              #{social_buttons}
+              <a href="#{h nav.dig('cta', 'sign_in', 'url')}" class="button tertiary compact hide-on-mobile">#{h nav.dig('cta', 'sign_in', 'text')}</a>
+              <a href="#{h nav.dig('cta', 'primary', 'url')}" class="button primary compact">#{h nav.dig('cta', 'primary', 'text')}</a>
+              <button class="button ghost compact nav-hamburger" data-mobile-toggle aria-label="Show menu">
+                <span class="fa-solid fa-bars icon m"></span>
+              </button>
+            </div>
+          </header>
+    HTML
+  end
+
+  def render_sections
+    @config['sections'].map do |section|
+      content_file = File.join(CONTENT_DIR, section['file'])
+      content = parse_markdown_file(content_file)
+      render_section(section['id'], content)
+    end.join("\n")
+  end
+
+  def parse_markdown_file(file_path)
+    content = File.read(file_path, encoding: 'UTF-8')
+
+    # Parse front matter
+    if content.start_with?('---')
+      parts = content.split('---', 3)
+      front_matter = YAML.safe_load(parts[1]) || {}
+      body = parts[2].strip
+    else
+      front_matter = {}
+      body = content.strip
+    end
+
+    { front_matter: front_matter, body: body }
+  end
+
+  def render_section(section_id, content)
+    case section_id
+    when 'hero'
+      render_hero_section(content)
+    when 'features'
+      render_features_section(content)
+    when 'pricing'
+      render_pricing_section(content)
+    when 'services'
+      render_services_section(content)
+    when 'add-ons'
+      render_addons_section(content)
+    when 'faq'
+      render_faq_section(content)
+    when 'cta'
+      render_cta_section(content)
+    else
+      "<section><!-- Unknown section: #{section_id} --></section>"
+    end
+  end
+
+  def render_hero_section(content)
+    fm = content[:front_matter]
+    body = content[:body]
+
+    # Parse the body - extract title, subtitle, and buttons
+    lines = body.lines.map(&:strip).reject(&:empty?)
+
+    # Find title lines (# **Active Agent** and # Build AI in Rails)
+    title_lines = []
+    subtitle_lines = []
+    buttons = []
+    in_buttons = false
+
+    lines.each do |line|
+      if line == '<!-- buttons -->'
+        in_buttons = true
+        next
+      end
+
+      if in_buttons
+        if line =~ /^\- \[(.+?)\]\((.+?)\)\{(.+?)\}$/
+          buttons << { text: $1, url: $2, classes: $3.gsub('.', ' ').strip }
+        end
+      elsif line.start_with?('# **')
+        # Title with accent - # **Active Agent**
+        title_lines << line.gsub(/^# \*\*(.+?)\*\*$/) { %(<span class="color-accent">#{$1}</span>) }
+      elsif line.start_with?('# ')
+        # Regular title line
+        title_lines << line.sub(/^# /, '')
+      else
+        subtitle_lines << line
+      end
+    end
+
+    title_html = title_lines.join("<br />\n      ")
+    subtitle_html = subtitle_lines.join("<br />\n      ")
+
+    buttons_html = buttons.map do |btn|
+      %(<a href="#{h btn[:url]}" class="#{btn[:classes]}">#{h btn[:text]}</a>)
+    end.join("\n      ")
+
+    image_html = if fm['image']
+      max_width = fm['image_max_width'] || '280px'
+      <<~HTML
+        <div style="display: flex; justify-content: center; margin-top: 2rem;">
+            <img src="#{h fm['image']}" alt="#{h @config.dig('brand', 'name')}" style="max-width: #{max_width}; height: auto;" />
+          </div>
+      HTML
+    else
+      ''
+    end
+
+    <<~HTML
+      <section>
+        <div class="heading hero centered">
+          <h1 class="balanced">
+            #{title_html}
+          </h1>
+          <p class="paragraph l secondary balanced">
+            #{subtitle_html}
+          </p>
+          <div class="button-group margin-paragraph centered">
+            #{buttons_html}
+          </div>
+        </div>
+        #{image_html}</section>
+    HTML
+  end
+
+  def render_features_section(content)
+    fm = content[:front_matter]
+    body = content[:body]
+
+    # Parse the body
+    lines = body.lines
+    title = ''
+    subtitle = ''
+    features = []
+    current_feature = nil
+
+    lines.each do |line|
+      line = line.rstrip
+      if line.start_with?('# ') && !line.start_with?('## ') && !line.start_with?('### ')
+        title = line.sub(/^# /, '')
+      elsif line.start_with?('## ') && !line.include?('Grid')
+        # Skip "## Features Grid" header
+      elsif !line.start_with?('## ') && subtitle.empty? && title != '' && !line.start_with?('#') && !line.strip.empty?
+        subtitle = line.strip
+      elsif line.start_with?('### ')
+        features << current_feature if current_feature
+        current_feature = { name: line.sub(/^### /, ''), description: '' }
+      elsif current_feature && !line.strip.empty?
+        current_feature[:description] += line.strip + ' '
+      end
+    end
+    features << current_feature if current_feature
+
+    # Group features into rows of 3
+    rows = features.each_slice(3).map do |row_features|
+      cards = row_features.map do |feature|
+        <<~HTML
+          <div class="feature-card">
+                <div class="feature-heading">
+                  <h3 class="color-accent no-top-margin">#{h feature[:name]}</h3>
+                  <p class="paragraph s secondary">
+                    #{h feature[:description].strip}
+                  </p>
+                </div>
+              </div>
+        HTML
+      end.join("\n    ")
+
+      %(<div class="grid columns-3">\n    #{cards}</div>)
+    end.join("\n  ")
+
+    <<~HTML
+      <section>
+        <div class="heading centered">
+          <h2 class="no-top-margin">#{h title}</h2>
+          <p class="paragraph m secondary">
+            #{h subtitle}
+          </p>
+        </div>
+        #{rows}
+      </section>
+    HTML
+  end
+
+  def render_pricing_section(content)
+    fm = content[:front_matter]
+    body = content[:body]
+    section_id = fm['id'] || 'pricing'
+
+    # Parse the body
+    lines = body.lines
+    title = ''
+    subtitle = ''
+    plans = []
+    current_plan = nil
+    in_comparison = false
+
+    lines.each do |line|
+      line = line.rstrip
+
+      if line.start_with?('# ') && !line.start_with?('## ') && !line.start_with?('### ')
+        title = line.sub(/^# /, '')
+      elsif line == '## Plans'
+        next
+      elsif line == '## Feature Comparison'
+        plans << current_plan if current_plan
+        current_plan = nil
+        in_comparison = true
+      elsif line.start_with?('|') && in_comparison
+        # Skip markdown tables - we'll render from existing HTML
+        next
+      elsif line.start_with?('### ') && !in_comparison
+        plans << current_plan if current_plan
+        current_plan = {
+          name: line.sub(/^### /, ''),
+          subtitle: '',
+          price: '',
+          price_period: '',
+          features: [],
+          best_for: '',
+          button: nil,
+          highlighted: false
+        }
+      elsif current_plan && !in_comparison
+        # Check for price line with format: **$99** /month or $995/yr
+        if line =~ /^\*\*(.+?)\*\*\s*(.*)$/ && !current_plan[:price_set]
+          bold_content = $1
+          remainder = $2.strip
+          if bold_content.include?('$') || bold_content == 'Free'
+            # It's a price line
+            current_plan[:price] = bold_content
+            current_plan[:price_period] = remainder unless remainder.empty?
+            current_plan[:price_set] = true
+          else
+            current_plan[:subtitle] = bold_content
+          end
+        elsif line.start_with?('*') && line.end_with?('*') && !line.start_with?('**')
+          text = line.gsub('*', '')
+          if text == 'highlighted'
+            current_plan[:highlighted] = true
+          elsif text.start_with?('Best for:')
+            current_plan[:best_for] = text
+          end
+        elsif line.start_with?('- ')
+          current_plan[:features] << line.sub(/^- /, '')
+        elsif line =~ /^\[(.+?)\]\((.+?)\)\{(.+?)\}$/
+          current_plan[:button] = { text: $1, url: $2, classes: $3.gsub('.', ' ').strip }
+        elsif line == '---'
+          # Plan separator, ignore
+        end
+      elsif !in_comparison && subtitle.empty? && !line.empty? && !line.start_with?('#')
+        subtitle = line
+      end
+    end
+    plans << current_plan if current_plan && !in_comparison
+
+    # Render plans
+    plan_cards = plans.map do |plan|
+      highlighted_class = plan[:highlighted] ? ' highlighted' : ''
+
+      features_html = plan[:features].map do |feature|
+        <<~HTML
+          <div class="feature-item paragraph s">
+                    <div class="fa-regular fa-square-check icon m"></div>
+                    <div>#{h feature}</div>
+                  </div>
+        HTML
+      end.join
+
+      price_html = if plan[:price_period].to_s.empty?
+        %(<div class="paragraph l bold">#{h plan[:price]}</div>)
+      else
+        %(<div class="paragraph l bold">#{h plan[:price]}</div>\n            <div class="paragraph m secondary">#{h plan[:price_period]}</div>)
+      end
+
+      button_class = plan[:highlighted] ? 'button primary full-width margin-top-l' : 'button tertiary full-width margin-top-l'
+      if plan[:button]
+        button_html = %(<a href="#{h plan[:button][:url]}" class="#{button_class}">#{h plan[:button][:text]}</a>)
+      else
+        button_html = ''
+      end
+
+      <<~HTML
+        <div class="feature-card justified-vertically#{highlighted_class}">
+              <div>
+                <div class="feature-heading">
+                  <p class="paragraph l bold no-top-margin">#{h plan[:name]}</p>
+                  <p class="paragraph s secondary">#{h plan[:subtitle]}</p>
+                  <div class="price-line">
+                    #{price_html}
+                  </div>
+                </div>
+                <div class="feature-list">
+                  #{features_html.strip}
+                </div>
+                <p class="paragraph xs secondary" style="margin-top: 1rem;">#{h plan[:best_for]}</p>
+              </div>
+              #{button_html}
+            </div>
+      HTML
+    end.join("\n    ")
+
+    # Feature comparison table (hardcoded for now - complex markdown table parsing)
+    comparison_table = render_feature_comparison_table
+
+    <<~HTML
+      <section id="#{h section_id}">
+        <div class="text-centered full-width">
+          <h2>#{h title}</h2>
+          <p class="paragraph m secondary">#{h subtitle}</p>
+        </div>
+        <div class="grid columns-3 margin-top-xl">
+          #{plan_cards.strip}
+        </div>
+        #{comparison_table}
+      </section>
+    HTML
+  end
+
+  def render_feature_comparison_table
+    <<~HTML
+      <div class="text-centered full-width margin-top-xl">
+          <h3 class="no-top-margin">Feature Comparison</h3>
+        </div>
+        <table class="pricing-table">
+          <thead>
+            <tr class="pricing-table-row">
+              <th class="paragraph s bold"></th>
+              <th class="paragraph s bold">Dev</th>
+              <th class="paragraph s bold">Pro</th>
+              <th class="paragraph s bold">Enterprise</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="pricing-table-row">
+              <td class="paragraph s bold" colspan="4" style="background: var(--color-bg-secondary);">Framework</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">ActiveAgent + SolidAgent gems</td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Multi-provider support</td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Tool calling & structured output</td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Streaming & embeddings</td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Local Web UI engine</td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s bold" colspan="4" style="background: var(--color-bg-secondary);">Hosted Platform</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Hosted dashboard</td>
+              <td></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Managed agent deployments</td>
+              <td></td>
+              <td class="paragraph s">3</td>
+              <td class="paragraph s">Unlimited</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Executions / month</td>
+              <td class="paragraph s">Self-hosted</td>
+              <td class="paragraph s">10,000</td>
+              <td class="paragraph s">Unlimited</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Traces / month</td>
+              <td class="paragraph s">Self-hosted</td>
+              <td class="paragraph s">25,000</td>
+              <td class="paragraph s">500,000+</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Trace retention</td>
+              <td></td>
+              <td class="paragraph s">14 days</td>
+              <td class="paragraph s">400 days</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s bold" colspan="4" style="background: var(--color-bg-secondary);">Observability & Evaluation</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Cost & latency analytics</td>
+              <td></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">LLM-as-judge evaluators</td>
+              <td></td>
+              <td class="paragraph s">5 prebuilt</td>
+              <td class="paragraph s">Unlimited custom</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">A/B prompt testing</td>
+              <td></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Anomaly detection (ML)</td>
+              <td></td>
+              <td></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s bold" colspan="4" style="background: var(--color-bg-secondary);">Team & Security</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Team seats</td>
+              <td class="paragraph s">1</td>
+              <td class="paragraph s">5</td>
+              <td class="paragraph s">Unlimited</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Workspaces</td>
+              <td></td>
+              <td class="paragraph s">1</td>
+              <td class="paragraph s">Unlimited</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">SSO / SAML & RBAC</td>
+              <td></td>
+              <td></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">SOC 2 Type II & HIPAA</td>
+              <td></td>
+              <td></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Private VPC / on-premise</td>
+              <td></td>
+              <td></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s bold" colspan="4" style="background: var(--color-bg-secondary);">Support</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Community (Discord, GitHub)</td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Email support SLA</td>
+              <td></td>
+              <td class="paragraph s">48 hours</td>
+              <td class="paragraph s">4 hours</td>
+            </tr>
+            <tr class="pricing-table-row">
+              <td class="paragraph s">Dedicated Slack channel</td>
+              <td></td>
+              <td></td>
+              <td><div class="fa-regular fa-square-check icon m"></div></td>
+            </tr>
+          </tbody>
+        </table>
+    HTML
+  end
+
+  def render_services_section(content)
+    fm = content[:front_matter]
+    body = content[:body]
+    section_id = fm['id'] || 'services'
+
+    # Parse the body
+    lines = body.lines
+    title = ''
+    subtitle = ''
+    services = []
+    current_service = nil
+
+    lines.each do |line|
+      line = line.rstrip
+
+      if line.start_with?('# ') && !line.start_with?('## ') && !line.start_with?('### ')
+        title = line.sub(/^# /, '')
+      elsif line == '## Services'
+        next
+      elsif line.start_with?('### ')
+        services << current_service if current_service
+        current_service = {
+          name: line.sub(/^### /, ''),
+          subtitle: '',
+          icon: nil,
+          features: [],
+          perfect_for: '',
+          button: nil,
+          highlighted: false
+        }
+      elsif current_service
+        if line.start_with?('**') && line.end_with?('**')
+          current_service[:subtitle] = line.gsub('**', '')
+        elsif line.start_with?('*') && line.end_with?('*') && !line.start_with?('**')
+          text = line.gsub('*', '')
+          if text == 'highlighted'
+            current_service[:highlighted] = true
+          elsif text.start_with?('icon:')
+            current_service[:icon] = text.sub('icon:', '').strip
+          elsif text.start_with?('Perfect for:')
+            current_service[:perfect_for] = text
+          end
+        elsif line.start_with?('- ')
+          current_service[:features] << line.sub(/^- /, '')
+        elsif line =~ /^\[(.+?)\]\((.+?)\)\{(.+?)\}$/
+          current_service[:button] = { text: $1, url: $2, classes: $3.gsub('.', ' ').strip }
+        elsif line == '---'
+          # Service separator, ignore
+        end
+      elsif subtitle.empty? && !line.empty? && !line.start_with?('#')
+        subtitle = line
+      end
+    end
+    services << current_service if current_service
+
+    # Render service cards
+    service_cards = services.map do |service|
+      highlighted_class = service[:highlighted] ? ' highlighted' : ''
+
+      icon_html = if service[:icon]
+        <<~HTML
+          <div class="service-icon">
+                    <div class="#{h service[:icon]} icon l color-accent"></div>
+                  </div>
+        HTML
+      else
+        ''
+      end
+
+      features_html = service[:features].map do |feature|
+        <<~HTML
+          <div class="feature-item paragraph s">
+                    <div class="fa-regular fa-square-check icon m"></div>
+                    <div>#{h feature}</div>
+                  </div>
+        HTML
+      end.join
+
+      button_class = service[:highlighted] ? 'button primary full-width margin-top-l' : 'button tertiary full-width margin-top-l'
+      if service[:button]
+        button_html = %(<a href="#{h service[:button][:url]}" class="#{button_class}">#{h service[:button][:text]}</a>)
+      else
+        button_html = ''
+      end
+
+      <<~HTML
+        <div class="feature-card justified-vertically#{highlighted_class}">
+              <div>
+                <div class="feature-heading">
+                  #{icon_html.strip}
+                  <p class="paragraph l bold no-top-margin">#{h service[:name]}</p>
+                  <p class="paragraph s secondary">#{h service[:subtitle]}</p>
+                </div>
+                <div class="feature-list">
+                  #{features_html.strip}
+                </div>
+                <p class="paragraph xs secondary" style="margin-top: 1rem;">#{h service[:perfect_for]}</p>
+              </div>
+              #{button_html}
+            </div>
+      HTML
+    end.join("\n    ")
+
+    <<~HTML
+      <section id="#{h section_id}">
+        <div class="text-centered full-width">
+          <h2>#{h title}</h2>
+          <p class="paragraph m secondary">#{h subtitle}</p>
+        </div>
+        <div class="grid columns-3 margin-top-xl">
+          #{service_cards.strip}
+        </div>
+      </section>
+    HTML
+  end
+
+  def render_addons_section(content)
+    fm = content[:front_matter]
+    body = content[:body]
+    section_id = fm['id'] || 'add-ons'
+
+    # Parse the body - complex structure with multiple subsections
+    lines = body.lines
+    title = ''
+    subtitle = ''
+    current_section = nil
+    current_subsection = nil
+    sections = {}
+
+    lines.each do |line|
+      line = line.rstrip
+
+      if line.start_with?('# ') && !line.start_with?('## ') && !line.start_with?('### ')
+        title = line.sub(/^# /, '')
+      elsif line.start_with?('## ')
+        current_section = line.sub(/^## /, '')
+        sections[current_section] = {}
+        current_subsection = nil
+      elsif line.start_with?('### ')
+        current_subsection = line.sub(/^### /, '')
+        sections[current_section][current_subsection] = { subtitle: '', items: [] } if current_section
+      elsif current_section && current_subsection
+        if line.start_with?('**') && line.end_with?('**')
+          sections[current_section][current_subsection][:subtitle] = line.gsub('**', '')
+        elsif line.start_with?('- ')
+          sections[current_section][current_subsection][:items] << line.sub(/^- /, '')
+        end
+      elsif subtitle.empty? && !line.empty? && !line.start_with?('#')
+        subtitle = line
+      end
+    end
+
+    # Render the complex add-ons section
+    render_full_addons_section(title, subtitle, section_id)
+  end
+
+  def render_full_addons_section(title, subtitle, section_id)
+    <<~HTML
+      <section id="#{h section_id}">
+        <div class="text-centered full-width">
+          <h2>#{h title}</h2>
+          <p class="paragraph m secondary">#{h subtitle}</p>
+        </div>
+        <div class="grid columns-2 margin-top-xl">
+          <div class="feature-card">
+            <div class="feature-heading">
+              <p class="paragraph l bold no-top-margin">Pro Add-Ons</p>
+              <p class="paragraph s secondary">Pay-as-you-grow pricing</p>
+            </div>
+            <div class="feature-list">
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Additional traces: $2.00/1k</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Additional executions: $0.01/exec</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Extended retention (400 days): $2.50/1k</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Additional team seats: $19/seat/mo</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Additional workspaces: $49/workspace/mo</div>
+              </div>
+            </div>
+          </div>
+          <div class="feature-card">
+            <div class="feature-heading">
+              <p class="paragraph l bold no-top-margin">Enterprise Add-Ons</p>
+              <p class="paragraph s secondary">Volume discounts included</p>
+            </div>
+            <div class="feature-list">
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Additional traces: $1.50/1k</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Additional executions: $0.005/exec</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Extended retention: Included</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Additional seats & workspaces: Included</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-circle icon m"></div>
+                <div>Appliance/embedded license: $14,995/yr</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="text-centered full-width margin-top-xl">
+          <h3 class="no-top-margin">Gem Licenses</h3>
+          <p class="paragraph s secondary">Software licensing for the Ruby gems</p>
+        </div>
+        <div class="grid columns-3" style="margin-top: 1rem;">
+          <div class="feature-card">
+            <div class="feature-heading">
+              <p class="paragraph m bold no-top-margin">activeagent</p>
+              <p class="paragraph s secondary">Open Source</p>
+            </div>
+            <div class="feature-list">
+              <div class="feature-item paragraph s">
+                <div class="fa-solid fa-scale-balanced icon m color-accent"></div>
+                <div><strong>MIT License</strong></div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Free forever, no restrictions</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Commercial use allowed</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Public GitHub repo</div>
+              </div>
+            </div>
+          </div>
+          <div class="feature-card">
+            <div class="feature-heading">
+              <p class="paragraph m bold no-top-margin">activeagent-pro</p>
+              <p class="paragraph s secondary">Commercial</p>
+            </div>
+            <div class="feature-list">
+              <div class="feature-item paragraph s">
+                <div class="fa-solid fa-scale-balanced icon m color-accent"></div>
+                <div><strong>Commercial License</strong></div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Private repo access for subscribers</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>License tied to subscription</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Bundler credentials provided</div>
+              </div>
+            </div>
+          </div>
+          <div class="feature-card">
+            <div class="feature-heading">
+              <p class="paragraph m bold no-top-margin">activeagent-enterprise</p>
+              <p class="paragraph s secondary">Commercial</p>
+            </div>
+            <div class="feature-list">
+              <div class="feature-item paragraph s">
+                <div class="fa-solid fa-scale-balanced icon m color-accent"></div>
+                <div><strong>Commercial License</strong></div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Private repo access for customers</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Multi-app & embedded licensing</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Custom terms available</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="text-centered full-width margin-top-xl">
+          <h3 class="no-top-margin">Service Subscriptions</h3>
+          <p class="paragraph s secondary">Hosted platform and support terms</p>
+        </div>
+        <div class="grid columns-2" style="margin-top: 1rem;">
+          <div class="feature-card">
+            <div class="feature-heading">
+              <p class="paragraph m bold no-top-margin">Pro Subscription</p>
+            </div>
+            <div class="feature-list">
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>14-day free trial, no credit card required</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Cancel anytime, no long-term commitment</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Annual plans: prorated refund if canceled</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Gem access active while subscribed</div>
+              </div>
+            </div>
+          </div>
+          <div class="feature-card">
+            <div class="feature-heading">
+              <p class="paragraph m bold no-top-margin">Enterprise Subscription</p>
+            </div>
+            <div class="feature-list">
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Custom contract terms & invoicing</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Volume discounts for large teams</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Dedicated onboarding & architecture review</div>
+              </div>
+              <div class="feature-item paragraph s">
+                <div class="fa-regular fa-square-check icon m"></div>
+                <div>Quarterly business reviews included</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="text-centered full-width margin-top-xl">
+          <h3 class="no-top-margin">Professional Services</h3>
+          <p class="paragraph s secondary">Consulting, training & custom development</p>
+        </div>
+        <div class="feature-card" style="margin-top: 1rem;">
+          <div class="grid columns-3">
+            <div>
+              <p class="paragraph s bold">Workshops</p>
+              <div class="feature-list">
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>Half-day: $2,500</div>
+                </div>
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>Full-day: $4,500</div>
+                </div>
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>Custom curriculum available</div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <p class="paragraph s bold">Advisory Retainers</p>
+              <div class="feature-list">
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>Monthly retainers from $3,000/mo</div>
+                </div>
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>Includes async Slack access</div>
+                </div>
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>Cancel with 30-day notice</div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <p class="paragraph s bold">Development</p>
+              <div class="feature-list">
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>Hourly: $250/hr</div>
+                </div>
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>Project-based quotes available</div>
+                </div>
+                <div class="feature-item paragraph s">
+                  <div class="fa-regular fa-circle icon m"></div>
+                  <div>SOW with milestones & deliverables</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    HTML
+  end
+
+  def render_faq_section(content)
+    body = content[:body]
+
+    # Parse the body
+    lines = body.lines
+    title = ''
+    subtitle = ''
+    questions = []
+    current_question = nil
+
+    lines.each do |line|
+      line = line.rstrip
+
+      if line.start_with?('# ') && !line.start_with?('## ') && !line.start_with?('### ')
+        title = line.sub(/^# /, '')
+      elsif line == '## Questions'
+        next
+      elsif line.start_with?('### ')
+        questions << current_question if current_question
+        current_question = { question: line.sub(/^### /, ''), answer: '' }
+      elsif current_question && !line.empty?
+        current_question[:answer] += line + ' '
+      elsif subtitle.empty? && !line.empty? && title != ''
+        subtitle = line
+      end
+    end
+    questions << current_question if current_question
+
+    # Convert markdown-style code to HTML
+    questions.each do |q|
+      q[:answer] = q[:answer].strip.gsub(/`([^`]+)`/, '<code>\1</code>')
+    end
+
+    accordion_items = questions.map do |q|
+      <<~HTML
+        <details class="accordion-item" name="faq">
+              <summary class="accordion-toggle">
+                <p class="paragraph m bold">#{h q[:question]}</p>
+                <span class="accordion-chevron fa-solid fa-chevron-down"></span>
+              </summary>
+              <div class="accordion-content">
+                <p>
+                  #{q[:answer]}
+                </p>
+              </div>
+            </details>
+      HTML
+    end.join("\n    ")
+
+    <<~HTML
+      <section>
+        <div class="heading centered">
+          <h2 class="no-top-margin">#{h title}</h2>
+          <p class="paragraph m secondary">
+            #{h subtitle}
+          </p>
+        </div>
+        <div class="accordion-container">
+          #{accordion_items.strip}
+        </div>
+      </section>
+    HTML
+  end
+
+  def render_cta_section(content)
+    fm = content[:front_matter]
+    body = content[:body]
+
+    section_class = fm['class'] || ''
+
+    # Parse the body
+    lines = body.lines.map(&:strip).reject(&:empty?)
+    title = ''
+    buttons = []
+    in_buttons = false
+
+    lines.each do |line|
+      if line == '<!-- buttons -->'
+        in_buttons = true
+        next
+      end
+
+      if in_buttons
+        if line =~ /^\- \[(.+?)\]\((.+?)\)\{(.+?)\}$/
+          buttons << { text: $1, url: $2, classes: $3.gsub('.', ' ').strip }
+        end
+      elsif line.start_with?('# ')
+        title = line.sub(/^# /, '')
+      end
+    end
+
+    buttons_html = buttons.map do |btn|
+      %(<a href="#{h btn[:url]}" class="#{btn[:classes]}">#{h btn[:text]}</a>)
+    end.join("\n      ")
+
+    <<~HTML
+      <section class="#{h section_class}">
+        <div class="heading centered">
+          <h2>#{h title}</h2>
+          <div class="button-group margin-paragraph centered">
+            #{buttons_html}
+          </div>
+        </div>
+      </section>
+    HTML
+  end
+
+  def render_footer
+    footer = @config['footer']
+
+    links_html = footer['links'].map do |link|
+      target = link['external'] ? ' target="_blank"' : ''
+      %(<a href="#{h link['url']}" class="ui s"#{target}>#{h link['text']}</a>)
+    end.join("\n            ")
+
+    social_html = footer['social'].map do |social|
+      <<~HTML
+        <a href="#{h social['url']}" class="icon-link ui s" target="_blank">
+                  <div class="#{h social['icon']} icon m color-accent"></div>
+                  <div class="pseudo-link">#{h social['label']}</div>
+                </a>
+      HTML
+    end.join
+
+    legal_html = footer['legal'].map do |legal|
+      %(<a href="#{h legal['url']}" class="ui s tertiary">#{h legal['text']}</a>)
+    end.join("\n        ")
+
+    <<~HTML
+      <footer class="footer">
+            <div class="footer-menu">
+              <div>
+                <p class="paragraph s">
+                  &copy; #{h footer['copyright']}<br />
+                  #{h footer['tagline']}
+                </p>
+              </div>
+              <div>
+                <div class="link-list">
+                  #{links_html}
+                </div>
+              </div>
+              <div>
+                <div class="link-list">
+                  #{social_html.strip}
+                </div>
+              </div>
+            </div>
+            <div class="link-list-horizontal">
+              #{legal_html}
+            </div>
+          </footer>
+    HTML
+  end
+
+  def h(text)
+    CGI.escapeHTML(text.to_s)
+  end
+end
+
+# Run the build
+if __FILE__ == $0
+  LanderBuilder.new.build
+end

--- a/docs/build.rb
+++ b/docs/build.rb
@@ -27,7 +27,12 @@ class LanderBuilder
   OUTPUT_FILE = File.join(DOCS_DIR, 'index.html')
 
   def initialize
-    @config = YAML.load_file(CONFIG_FILE)
+    @config = YAML.safe_load_file(
+      CONFIG_FILE,
+      permitted_classes: [],
+      permitted_symbols: [],
+      aliases: true
+    )
   end
 
   def build

--- a/docs/content/lander.yml
+++ b/docs/content/lander.yml
@@ -1,0 +1,115 @@
+# Active Agent Landing Page Configuration
+# This file defines the structure and metadata for the landing page.
+# Section content is stored in separate markdown files in the sections/ directory.
+
+meta:
+  title: "Active Agent | The AI Framework For Ruby on Rails"
+  description: "Build AI in Rails - Now Agents are Controllers. The Ruby-native way to build AI features."
+
+  # Open Graph
+  og:
+    type: website
+    site_name: Active Agent
+    locale: en_US
+    title: "Active Agent | The AI Framework For Ruby on Rails"
+    description: "Build AI in Rails - Now Agents are Controllers. Makes code tons of fun!"
+    url: https://activeagents.ai
+
+  # Twitter/X
+  twitter:
+    site: "@activeagents"
+    card: summary_large_image
+    title: "Active Agent | The AI Framework For Ruby on Rails"
+    description: "Build AI in Rails - Now Agents are Controllers."
+
+  # Favicon
+  favicon: images/activeagent-logo.png
+
+# Brand information
+brand:
+  name: Active Agent
+  logo: images/activeagent-logo.png
+  tagline: "The AI Framework for Ruby on Rails"
+
+# Navigation links
+navigation:
+  links:
+    - text: Docs
+      url: https://docs.activeagents.ai
+    - text: Pricing
+      url: "#pricing"
+    - text: GitHub
+      url: https://github.com/activeagents/activeagent
+
+  social:
+    - icon: fa-brands fa-github
+      url: https://github.com/activeagents/activeagent
+      label: GitHub
+    - icon: fa-brands fa-discord
+      url: https://discord.gg/activeagent
+      label: Discord
+
+  cta:
+    sign_in:
+      text: Sign In
+      url: https://activeagents.ai/dashboard
+    primary:
+      text: Getting Started
+      url: https://docs.activeagents.ai/getting-started
+
+# Page sections - each references a markdown file
+sections:
+  - id: hero
+    file: sections/hero.md
+
+  - id: features
+    file: sections/features.md
+
+  - id: pricing
+    file: sections/pricing.md
+
+  - id: services
+    file: sections/services.md
+
+  - id: add-ons
+    file: sections/add-ons.md
+
+  - id: faq
+    file: sections/faq.md
+
+  - id: cta
+    file: sections/cta.md
+
+# Footer configuration
+footer:
+  copyright: "2026 Active Agent"
+  tagline: "The AI Framework for Ruby on Rails"
+
+  links:
+    - text: Documentation
+      url: https://docs.activeagents.ai
+    - text: Pricing
+      url: "#pricing"
+    - text: GitHub
+      url: https://github.com/activeagents/activeagent
+      external: true
+
+  social:
+    - icon: fa-brands fa-github
+      url: https://github.com/activeagents/activeagent
+      label: GitHub
+    - icon: fa-brands fa-discord
+      url: https://discord.gg/activeagent
+      label: Discord
+    - icon: fa-brands fa-x-twitter
+      url: https://x.com/activeagents
+      label: Twitter
+    - icon: fa-brands fa-bluesky
+      url: https://bsky.app/profile/activeagent.dev
+      label: Bluesky
+
+  legal:
+    - text: Privacy Policy
+      url: "#"
+    - text: Terms of Service
+      url: "#"

--- a/docs/content/sections/add-ons.md
+++ b/docs/content/sections/add-ons.md
@@ -1,0 +1,97 @@
+---
+# Add-Ons & Licensing Section Configuration
+layout: add-ons
+id: add-ons
+---
+
+# Add-Ons & Licensing
+
+Scale beyond your plan with transparent usage-based pricing
+
+## Platform Add-Ons
+
+### Pro Add-Ons
+**Pay-as-you-grow pricing**
+
+- Additional traces: $2.00/1k
+- Additional executions: $0.01/exec
+- Extended retention (400 days): $2.50/1k
+- Additional team seats: $19/seat/mo
+- Additional workspaces: $49/workspace/mo
+
+### Enterprise Add-Ons
+**Volume discounts included**
+
+- Additional traces: $1.50/1k
+- Additional executions: $0.005/exec
+- Extended retention: Included
+- Additional seats & workspaces: Included
+- Appliance/embedded license: $14,995/yr
+
+## Gem Licenses
+
+Software licensing for the Ruby gems
+
+### activeagent
+**Open Source**
+
+- **MIT License**
+- Free forever, no restrictions
+- Commercial use allowed
+- Public GitHub repo
+
+### activeagent-pro
+**Commercial**
+
+- **Commercial License**
+- Private repo access for subscribers
+- License tied to subscription
+- Bundler credentials provided
+
+### activeagent-enterprise
+**Commercial**
+
+- **Commercial License**
+- Private repo access for customers
+- Multi-app & embedded licensing
+- Custom terms available
+
+## Service Subscriptions
+
+Hosted platform and support terms
+
+### Pro Subscription
+
+- 14-day free trial, no credit card required
+- Cancel anytime, no long-term commitment
+- Annual plans: prorated refund if canceled
+- Gem access active while subscribed
+
+### Enterprise Subscription
+
+- Custom contract terms & invoicing
+- Volume discounts for large teams
+- Dedicated onboarding & architecture review
+- Quarterly business reviews included
+
+## Professional Services
+
+Consulting, training & custom development
+
+### Workshops
+
+- Half-day: $2,500
+- Full-day: $4,500
+- Custom curriculum available
+
+### Advisory Retainers
+
+- Monthly retainers from $3,000/mo
+- Includes async Slack access
+- Cancel with 30-day notice
+
+### Development
+
+- Hourly: $250/hr
+- Project-based quotes available
+- SOW with milestones & deliverables

--- a/docs/content/sections/cta.md
+++ b/docs/content/sections/cta.md
@@ -1,0 +1,11 @@
+---
+# Call to Action Section Configuration
+layout: cta
+class: promo-cta
+---
+
+# Ready to build AI products in Rails?
+
+<!-- buttons -->
+- [Getting Started](https://docs.activeagents.ai/getting-started){.button.primary}
+- [View Documentation](https://docs.activeagents.ai){.button.tertiary}

--- a/docs/content/sections/faq.md
+++ b/docs/content/sections/faq.md
@@ -1,0 +1,39 @@
+---
+# FAQ Section Configuration
+layout: faq
+---
+
+# FAQ
+
+Common questions about Active Agent
+
+## Questions
+
+### How do I install Active Agent?
+
+Add `gem 'activeagent'` to your Gemfile and run `bundle install`.
+Then run `rails generate active_agent:install` to set up the initial configuration.
+
+### Which LLM providers are supported?
+
+Active Agent supports OpenAI, Anthropic, Ollama, and OpenRouter. Switch providers with one line of code.
+
+### Can I use Active Agent with existing Rails apps?
+
+Yes! Active Agent is designed to integrate seamlessly with existing Rails applications. It works alongside your existing models, controllers, and services.
+
+### What's the difference between Community and Pro?
+
+The Community tier gives you full access to the open-source framework (ActiveAgent + SolidAgent gems) with all core features and community support. Pro ($99/mo or $995/yr) adds hosted observability with trace dashboards, managed agent deployments, cost & latency analytics, LLM-as-judge evaluators, A/B prompt testing, and 48-hour email support SLA.
+
+### What does Enterprise include?
+
+Enterprise (starting at $2,995/yr) is for large organizations and regulated industries. It includes everything in Pro plus unlimited deployments and executions, 500,000+ traces with 400-day retention, advanced ML-powered anomaly detection, unlimited custom evaluators, SOC 2 Type II & HIPAA compliance, SSO/SAML & RBAC, private VPC deployment options, dedicated Slack channel, 4-hour email SLA, onboarding workshop, and quarterly architecture consultations.
+
+### Is there a free trial for Pro?
+
+Yes! Pro includes a 14-day free trial with no credit card required. You can explore all Pro features before committing.
+
+### Can I self-host Active Agent?
+
+Absolutely! The core framework is MIT licensed and can be self-hosted without limits on any tier. The hosted services (observability, evaluation, collaboration) are what differentiate the paid tiers.

--- a/docs/content/sections/features.md
+++ b/docs/content/sections/features.md
@@ -1,0 +1,47 @@
+---
+# Features Section Configuration
+layout: features
+columns: 3
+---
+
+# Features
+
+Everything you need to build AI-powered Rails applications
+
+## Features Grid
+
+### Agents
+
+Controllers for AI. Define actions, use callbacks, render views. Rails conventions for LLM interactions.
+
+### Tool Calling
+
+AI calls Ruby methods to fetch data and make decisions. Works like RPC for agents.
+
+### Structured Output
+
+Extract typed data with JSON schemas. Validated responses for forms and APIs.
+
+### Providers
+
+OpenAI, Anthropic, Ollama, OpenRouter. Switch providers with one line of code.
+
+### Streaming
+
+Real-time response streaming with callbacks for dynamic UIs and live updates.
+
+### Embeddings
+
+Generate vectors for semantic search, RAG, and clustering applications.
+
+### Testing
+
+Test with fixtures and VCR cassettes. Mock providers for fast tests.
+
+### Background Jobs
+
+Process generations async with Active Job. Scale AI operations in the background.
+
+### Error Handling
+
+Automatic retries with exponential backoff. Graceful degradation for production.

--- a/docs/content/sections/hero.md
+++ b/docs/content/sections/hero.md
@@ -1,0 +1,17 @@
+---
+# Hero Section Configuration
+layout: hero
+image: images/activeagent-logo.png
+image_max_width: 280px
+---
+
+# **Active Agent**
+# Build AI in Rails
+
+Now Agents are Controllers
+Makes code tons of fun!
+
+<!-- buttons -->
+- [Getting Started](https://docs.activeagents.ai/getting-started){.button.primary}
+- [Docs](https://docs.activeagents.ai){.button.tertiary}
+- [GitHub](https://github.com/activeagents/activeagent){.button.tertiary}

--- a/docs/content/sections/pricing.md
+++ b/docs/content/sections/pricing.md
@@ -1,0 +1,106 @@
+---
+# Pricing Section Configuration
+layout: pricing
+id: pricing
+columns: 3
+---
+
+# Choose Your Plan
+
+Rails-native AI framework with hosted observability, evaluation, and collaboration tools
+
+## Plans
+
+### ActiveAgent.dev
+**Community - Free Forever**
+
+**Free**
+
+- Full ActiveAgent + SolidAgent gems
+- All core framework features
+- Multi-provider support (OpenAI, Anthropic, Ollama, OpenRouter)
+- Basic local Web UI Rails engine
+- Community support (Discord, GitHub)
+- Self-hosted (unlimited)
+- MIT License
+
+*Best for: Individual developers, startups validating ideas, open-source projects*
+
+[Get Started](https://github.com/activeagents/activeagent){.button.tertiary.full-width}
+
+---
+
+### ActiveAgent.pro
+**For small/medium teams & consultants**
+*highlighted*
+
+**$99** /month or $995/yr
+
+- Everything in Community
+- Hosted dashboard at app.activeagent.pro
+- 3 managed agent deployments
+- 10,000 executions/month
+- 25,000 traces/month (14-day retention)
+- Cost & latency analytics
+- 5 prebuilt LLM-as-judge evaluators
+- A/B prompt testing
+- 5 team seats, 1 workspace
+- 48-hour email support SLA
+
+*Best for: Small teams, Rails consultants, startups moving to production*
+
+[Start 14-Day Free Trial](https://activeagents.ai/dashboard){.button.primary.full-width}
+
+---
+
+### ActiveAgent.enterprise
+**For large orgs & regulated industries**
+
+**$2,995+** /year
+
+- Everything in Pro
+- Unlimited agent deployments & executions
+- 500,000+ traces/month (400-day retention)
+- Advanced anomaly detection (ML-powered)
+- Unlimited custom evaluators & datasets
+- SOC 2 Type II & HIPAA compliance
+- SSO/SAML & RBAC
+- Private VPC / on-premise deployment
+- Dedicated Slack channel
+- 4-hour email SLA
+
+*Best for: Large enterprises, regulated industries, compliance-heavy environments*
+
+[Contact Sales](mailto:sales@activeagents.ai){.button.tertiary.full-width}
+
+## Feature Comparison
+
+| Feature | Dev | Pro | Enterprise |
+|---------|-----|-----|------------|
+| **Framework** | | | |
+| ActiveAgent + SolidAgent gems | ✓ | ✓ | ✓ |
+| Multi-provider support | ✓ | ✓ | ✓ |
+| Tool calling & structured output | ✓ | ✓ | ✓ |
+| Streaming & embeddings | ✓ | ✓ | ✓ |
+| Local Web UI engine | ✓ | ✓ | ✓ |
+| **Hosted Platform** | | | |
+| Hosted dashboard | | ✓ | ✓ |
+| Managed agent deployments | | 3 | Unlimited |
+| Executions / month | Self-hosted | 10,000 | Unlimited |
+| Traces / month | Self-hosted | 25,000 | 500,000+ |
+| Trace retention | | 14 days | 400 days |
+| **Observability & Evaluation** | | | |
+| Cost & latency analytics | | ✓ | ✓ |
+| LLM-as-judge evaluators | | 5 prebuilt | Unlimited custom |
+| A/B prompt testing | | ✓ | ✓ |
+| Anomaly detection (ML) | | | ✓ |
+| **Team & Security** | | | |
+| Team seats | 1 | 5 | Unlimited |
+| Workspaces | | 1 | Unlimited |
+| SSO / SAML & RBAC | | | ✓ |
+| SOC 2 Type II & HIPAA | | | ✓ |
+| Private VPC / on-premise | | | ✓ |
+| **Support** | | | |
+| Community (Discord, GitHub) | ✓ | ✓ | ✓ |
+| Email support SLA | | 48 hours | 4 hours |
+| Dedicated Slack channel | | | ✓ |

--- a/docs/content/sections/services.md
+++ b/docs/content/sections/services.md
@@ -1,0 +1,60 @@
+---
+# Training & Consulting Section Configuration
+layout: services
+id: services
+columns: 3
+---
+
+# Training & Consulting
+
+White-glove services to accelerate your AI journey
+
+## Services
+
+### Workshops
+**For indie developers & small teams**
+*icon: fa-solid fa-graduation-cap*
+
+- Half-day or full-day intensive sessions
+- Hands-on coding with Active Agent
+- Build your first AI agent in Rails
+- Best practices & architecture patterns
+- Q&A and code review
+
+*Perfect for: Indie hackers, freelancers, and developers looking to add AI capabilities*
+
+[Join a Workshop](mailto:workshops@activeagents.ai?subject=Workshop%20Inquiry){.button.tertiary.full-width}
+
+---
+
+### Strategic Leadership
+**For startups & agencies**
+*highlighted*
+*icon: fa-solid fa-compass*
+
+- Ongoing AI strategy & architecture guidance
+- Monthly retainer with dedicated advisor
+- Code reviews & pull request feedback
+- Team training & mentorship
+- Roadmap planning & prioritization
+- Slack access for async questions
+
+*Perfect for: Growing teams needing ongoing expert guidance to ship AI features faster*
+
+[Schedule a Call](mailto:consulting@activeagents.ai?subject=Strategic%20Leadership%20Inquiry){.button.primary.full-width}
+
+---
+
+### Development Services
+**Hourly or project-based**
+*icon: fa-solid fa-code*
+
+- Custom agent development
+- Integration with existing Rails apps
+- Performance optimization
+- Production deployment support
+- Flexible engagement models
+
+*Perfect for: Teams with specific projects or needing extra hands for AI implementation*
+
+[Get in Touch](mailto:dev@activeagents.ai?subject=Development%20Services%20Inquiry){.button.tertiary.full-width}

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,6 +66,7 @@
         </button>
       </div>
     </header>
+
     <main>
       <section>
   <div class="heading hero centered">
@@ -104,6 +105,7 @@
         </p>
       </div>
     </div>
+
     <div class="feature-card">
       <div class="feature-heading">
         <h3 class="color-accent no-top-margin">Tool Calling</h3>
@@ -112,6 +114,7 @@
         </p>
       </div>
     </div>
+
     <div class="feature-card">
       <div class="feature-heading">
         <h3 class="color-accent no-top-margin">Structured Output</h3>
@@ -120,7 +123,7 @@
         </p>
       </div>
     </div>
-  </div>
+</div>
   <div class="grid columns-3">
     <div class="feature-card">
       <div class="feature-heading">
@@ -130,6 +133,7 @@
         </p>
       </div>
     </div>
+
     <div class="feature-card">
       <div class="feature-heading">
         <h3 class="color-accent no-top-margin">Streaming</h3>
@@ -138,6 +142,7 @@
         </p>
       </div>
     </div>
+
     <div class="feature-card">
       <div class="feature-heading">
         <h3 class="color-accent no-top-margin">Embeddings</h3>
@@ -146,7 +151,7 @@
         </p>
       </div>
     </div>
-  </div>
+</div>
   <div class="grid columns-3">
     <div class="feature-card">
       <div class="feature-heading">
@@ -156,6 +161,7 @@
         </p>
       </div>
     </div>
+
     <div class="feature-card">
       <div class="feature-heading">
         <h3 class="color-accent no-top-margin">Background Jobs</h3>
@@ -164,6 +170,7 @@
         </p>
       </div>
     </div>
+
     <div class="feature-card">
       <div class="feature-heading">
         <h3 class="color-accent no-top-margin">Error Handling</h3>
@@ -172,7 +179,7 @@
         </p>
       </div>
     </div>
-  </div>
+</div>
 </section>
 
 <section id="pricing">
@@ -192,43 +199,44 @@
         </div>
         <div class="feature-list">
           <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Full ActiveAgent + SolidAgent gems</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>All core framework features</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Multi-provider support (OpenAI, Anthropic, Ollama, OpenRouter)</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Basic local Web UI Rails engine</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Community support (Discord, GitHub)</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Self-hosted (unlimited)</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>MIT License</div>
-          </div>
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Full ActiveAgent + SolidAgent gems</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>All core framework features</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Multi-provider support (OpenAI, Anthropic, Ollama, OpenRouter)</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Basic local Web UI Rails engine</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Community support (Discord, GitHub)</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Self-hosted (unlimited)</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>MIT License</div>
+        </div>
         </div>
         <p class="paragraph xs secondary" style="margin-top: 1rem;">Best for: Individual developers, startups validating ideas, open-source projects</p>
       </div>
       <a href="https://github.com/activeagents/activeagent" class="button tertiary full-width margin-top-l">Get Started</a>
     </div>
+
     <div class="feature-card justified-vertically highlighted">
       <div>
         <div class="feature-heading">
           <p class="paragraph l bold no-top-margin">ActiveAgent.pro</p>
-          <p class="paragraph s secondary">For small/medium teams & consultants</p>
+          <p class="paragraph s secondary">For small/medium teams &amp; consultants</p>
           <div class="price-line">
             <div class="paragraph l bold">$99</div>
             <div class="paragraph m secondary">/month or $995/yr</div>
@@ -236,55 +244,56 @@
         </div>
         <div class="feature-list">
           <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Everything in Community</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Hosted dashboard at app.activeagent.pro</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>3 managed agent deployments</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>10,000 executions/month</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>25,000 traces/month (14-day retention)</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Cost & latency analytics</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>5 prebuilt LLM-as-judge evaluators</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>A/B prompt testing</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>5 team seats, 1 workspace</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>48-hour email support SLA</div>
-          </div>
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Everything in Community</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Hosted dashboard at app.activeagent.pro</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>3 managed agent deployments</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>10,000 executions/month</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>25,000 traces/month (14-day retention)</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Cost &amp; latency analytics</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>5 prebuilt LLM-as-judge evaluators</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>A/B prompt testing</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>5 team seats, 1 workspace</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>48-hour email support SLA</div>
+        </div>
         </div>
         <p class="paragraph xs secondary" style="margin-top: 1rem;">Best for: Small teams, Rails consultants, startups moving to production</p>
       </div>
       <a href="https://activeagents.ai/dashboard" class="button primary full-width margin-top-l">Start 14-Day Free Trial</a>
     </div>
+
     <div class="feature-card justified-vertically">
       <div>
         <div class="feature-heading">
           <p class="paragraph l bold no-top-margin">ActiveAgent.enterprise</p>
-          <p class="paragraph s secondary">For large orgs & regulated industries</p>
+          <p class="paragraph s secondary">For large orgs &amp; regulated industries</p>
           <div class="price-line">
             <div class="paragraph l bold">$2,995+</div>
             <div class="paragraph m secondary">/year</div>
@@ -292,45 +301,45 @@
         </div>
         <div class="feature-list">
           <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Everything in Pro</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Unlimited agent deployments & executions</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>500,000+ traces/month (400-day retention)</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Advanced anomaly detection (ML-powered)</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Unlimited custom evaluators & datasets</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>SOC 2 Type II & HIPAA compliance</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>SSO/SAML & RBAC</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Private VPC / on-premise deployment</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Dedicated Slack channel</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>4-hour email SLA</div>
-          </div>
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Everything in Pro</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Unlimited agent deployments &amp; executions</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>500,000+ traces/month (400-day retention)</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Advanced anomaly detection (ML-powered)</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Unlimited custom evaluators &amp; datasets</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>SOC 2 Type II &amp; HIPAA compliance</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>SSO/SAML &amp; RBAC</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Private VPC / on-premise deployment</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Dedicated Slack channel</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>4-hour email SLA</div>
+        </div>
         </div>
         <p class="paragraph xs secondary" style="margin-top: 1rem;">Best for: Large enterprises, regulated industries, compliance-heavy environments</p>
       </div>
@@ -499,11 +508,12 @@
       </tr>
     </tbody>
   </table>
+
 </section>
 
 <section id="services">
   <div class="text-centered full-width">
-    <h2>Training & Consulting</h2>
+    <h2>Training &amp; Consulting</h2>
     <p class="paragraph m secondary">White-glove services to accelerate your AI journey</p>
   </div>
   <div class="grid columns-3 margin-top-xl">
@@ -511,106 +521,108 @@
       <div>
         <div class="feature-heading">
           <div class="service-icon">
-            <div class="fa-solid fa-graduation-cap icon l color-accent"></div>
-          </div>
+          <div class="fa-solid fa-graduation-cap icon l color-accent"></div>
+        </div>
           <p class="paragraph l bold no-top-margin">Workshops</p>
-          <p class="paragraph s secondary">For indie developers & small teams</p>
+          <p class="paragraph s secondary">For indie developers &amp; small teams</p>
         </div>
         <div class="feature-list">
           <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Half-day or full-day intensive sessions</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Hands-on coding with Active Agent</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Build your first AI agent in Rails</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Best practices & architecture patterns</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Q&A and code review</div>
-          </div>
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Half-day or full-day intensive sessions</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Hands-on coding with Active Agent</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Build your first AI agent in Rails</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Best practices &amp; architecture patterns</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Q&amp;A and code review</div>
+        </div>
         </div>
         <p class="paragraph xs secondary" style="margin-top: 1rem;">Perfect for: Indie hackers, freelancers, and developers looking to add AI capabilities</p>
       </div>
       <a href="mailto:workshops@activeagents.ai?subject=Workshop%20Inquiry" class="button tertiary full-width margin-top-l">Join a Workshop</a>
     </div>
+
     <div class="feature-card justified-vertically highlighted">
       <div>
         <div class="feature-heading">
           <div class="service-icon">
-            <div class="fa-solid fa-compass icon l color-accent"></div>
-          </div>
+          <div class="fa-solid fa-compass icon l color-accent"></div>
+        </div>
           <p class="paragraph l bold no-top-margin">Strategic Leadership</p>
-          <p class="paragraph s secondary">For startups & agencies</p>
+          <p class="paragraph s secondary">For startups &amp; agencies</p>
         </div>
         <div class="feature-list">
           <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Ongoing AI strategy & architecture guidance</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Monthly retainer with dedicated advisor</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Code reviews & pull request feedback</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Team training & mentorship</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Roadmap planning & prioritization</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Slack access for async questions</div>
-          </div>
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Ongoing AI strategy &amp; architecture guidance</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Monthly retainer with dedicated advisor</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Code reviews &amp; pull request feedback</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Team training &amp; mentorship</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Roadmap planning &amp; prioritization</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Slack access for async questions</div>
+        </div>
         </div>
         <p class="paragraph xs secondary" style="margin-top: 1rem;">Perfect for: Growing teams needing ongoing expert guidance to ship AI features faster</p>
       </div>
       <a href="mailto:consulting@activeagents.ai?subject=Strategic%20Leadership%20Inquiry" class="button primary full-width margin-top-l">Schedule a Call</a>
     </div>
+
     <div class="feature-card justified-vertically">
       <div>
         <div class="feature-heading">
           <div class="service-icon">
-            <div class="fa-solid fa-code icon l color-accent"></div>
-          </div>
+          <div class="fa-solid fa-code icon l color-accent"></div>
+        </div>
           <p class="paragraph l bold no-top-margin">Development Services</p>
           <p class="paragraph s secondary">Hourly or project-based</p>
         </div>
         <div class="feature-list">
           <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Custom agent development</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Integration with existing Rails apps</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Performance optimization</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Production deployment support</div>
-          </div>
-          <div class="feature-item paragraph s">
-            <div class="fa-regular fa-square-check icon m"></div>
-            <div>Flexible engagement models</div>
-          </div>
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Custom agent development</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Integration with existing Rails apps</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Performance optimization</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Production deployment support</div>
+        </div>
+<div class="feature-item paragraph s">
+          <div class="fa-regular fa-square-check icon m"></div>
+          <div>Flexible engagement models</div>
+        </div>
         </div>
         <p class="paragraph xs secondary" style="margin-top: 1rem;">Perfect for: Teams with specific projects or needing extra hands for AI implementation</p>
       </div>
@@ -621,7 +633,7 @@
 
 <section id="add-ons">
   <div class="text-centered full-width">
-    <h2>Add-Ons & Licensing</h2>
+    <h2>Add-Ons &amp; Licensing</h2>
     <p class="paragraph m secondary">Scale beyond your plan with transparent usage-based pricing</p>
   </div>
   <div class="grid columns-2 margin-top-xl">
@@ -888,8 +900,7 @@
       </summary>
       <div class="accordion-content">
         <p>
-          Add <code>gem 'activeagent'</code> to your Gemfile and run <code>bundle install</code>.
-          Then run <code>rails generate active_agent:install</code> to set up the initial configuration.
+          Add <code>gem 'activeagent'</code> to your Gemfile and run <code>bundle install</code>. Then run <code>rails generate active_agent:install</code> to set up the initial configuration.
         </p>
       </div>
     </details>
@@ -920,7 +931,7 @@
 
     <details class="accordion-item" name="faq">
       <summary class="accordion-toggle">
-        <p class="paragraph m bold">What's the difference between Community and Pro?</p>
+        <p class="paragraph m bold">What&#39;s the difference between Community and Pro?</p>
         <span class="accordion-chevron fa-solid fa-chevron-down"></span>
       </summary>
       <div class="accordion-content">
@@ -977,6 +988,7 @@
     </div>
   </div>
 </section>
+
     </main>
     <footer class="footer">
       <div class="footer-menu">
@@ -996,21 +1008,21 @@
         <div>
           <div class="link-list">
             <a href="https://github.com/activeagents/activeagent" class="icon-link ui s" target="_blank">
-              <div class="fa-brands fa-github icon m color-accent"></div>
-              <div class="pseudo-link">GitHub</div>
-            </a>
-            <a href="https://discord.gg/activeagent" class="icon-link ui s" target="_blank">
-              <div class="fa-brands fa-discord icon m color-accent"></div>
-              <div class="pseudo-link">Discord</div>
-            </a>
-            <a href="https://x.com/activeagents" class="icon-link ui s" target="_blank">
-              <div class="fa-brands fa-x-twitter icon m color-accent"></div>
-              <div class="pseudo-link">Twitter</div>
-            </a>
-            <a href="https://bsky.app/profile/activeagent.dev" class="icon-link ui s" target="_blank">
-              <div class="fa-brands fa-bluesky icon m color-accent"></div>
-              <div class="pseudo-link">Bluesky</div>
-            </a>
+          <div class="fa-brands fa-github icon m color-accent"></div>
+          <div class="pseudo-link">GitHub</div>
+        </a>
+<a href="https://discord.gg/activeagent" class="icon-link ui s" target="_blank">
+          <div class="fa-brands fa-discord icon m color-accent"></div>
+          <div class="pseudo-link">Discord</div>
+        </a>
+<a href="https://x.com/activeagents" class="icon-link ui s" target="_blank">
+          <div class="fa-brands fa-x-twitter icon m color-accent"></div>
+          <div class="pseudo-link">Twitter</div>
+        </a>
+<a href="https://bsky.app/profile/activeagent.dev" class="icon-link ui s" target="_blank">
+          <div class="fa-brands fa-bluesky icon m color-accent"></div>
+          <div class="pseudo-link">Bluesky</div>
+        </a>
           </div>
         </div>
       </div>
@@ -1019,6 +1031,7 @@
         <a href="#" class="ui s tertiary">Terms of Service</a>
       </div>
     </footer>
+
   </div>
 </body>
 


### PR DESCRIPTION
Let's make the lander contents that live in docs/index.html rendered from a yml file structured with sections' contents in markdown files which correspond to their HTML sections. This will make the content easier to edit without the clutter of the HTML in the way for the human or the developer/writer.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/HKwJrbTCnngm/implementations/GmRqCzJztgRK)