### PR TITLE
Change "free tire gems" to a more relevant term for Ruby on Rails open source software

### DIFF
--- a/docs/content/landing.yml
+++ b/docs/content/landing.yml
@@ -63,7 +63,7 @@ hero:
       class: button tertiary
 
 features:
-  heading: Free Tier Gems
+  heading: Open Source Gems
   subheading: "Everything you need to build AI-powered Rails applications \u2014 free and open source"
   items:
     - title: Active Agent
@@ -366,8 +366,8 @@ faq:
   items:
     - question: How do I install Active Agent?
       answer: "Add `gem 'activeagent'` to your Gemfile and run `bundle install`. Then run `rails generate active_agent:install` to set up the initial configuration."
-    - question: What gems are included in the free tier?
-      answer: "The free tier includes the Active Agent gem, Action Prompt, and all Generation Provider modules (RubyLLM, OpenAI, Anthropic \u2014 both official and community gems). You also get Instrumentation, Error Handling, and Retries modules at no cost."
+    - question: What open source gems are included?
+      answer: "The open source gems include Active Agent, Action Prompt, and all Generation Provider modules (RubyLLM, OpenAI, Anthropic \u2014 both official and community gems). You also get Instrumentation, Error Handling, and Retries modules \u2014 all MIT licensed."
     - question: Which Generation Providers are supported?
       answer: "Active Agent supports multiple providers through its Generation Providers module: RubyLLM, OpenAI (official and community gems), Anthropic (official and community gems), Ollama, and OpenRouter. Switch providers with one line of code."
     - question: What are the Reasonable Reasons gems in Pro?

--- a/docs/index.html
+++ b/docs/index.html
@@ -90,7 +90,7 @@
 
 <section>
   <div class="heading centered">
-    <h2 class="no-top-margin">Free Tier Gems</h2>
+    <h2 class="no-top-margin">Open Source Gems</h2>
     <p class="paragraph m secondary">
       Everything you need to build AI-powered Rails applications — free and open source
     </p>
@@ -973,12 +973,12 @@
 
     <details class="accordion-item" name="faq">
       <summary class="accordion-toggle">
-        <p class="paragraph m bold">What gems are included in the free tier?</p>
+        <p class="paragraph m bold">What open source gems are included?</p>
         <span class="accordion-chevron fa-solid fa-chevron-down"></span>
       </summary>
       <div class="accordion-content">
         <p>
-          The free tier includes the Active Agent gem, Action Prompt, and all Generation Provider modules (RubyLLM, OpenAI, Anthropic — both official and community gems). You also get Instrumentation, Error Handling, and Retries modules at no cost.
+          The open source gems include Active Agent, Action Prompt, and all Generation Provider modules (RubyLLM, OpenAI, Anthropic — both official and community gems). You also get Instrumentation, Error Handling, and Retries modules — all MIT licensed.
         </p>
       </div>
     </details>


### PR DESCRIPTION
Change “free tire gems” to something more relevant to Ruby on rails open source software 

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/8PQjRBJPL8Pw/implementations/8JH6BMQmJB9T)