### PR TITLE
fix(stripe): Align env var names with GCP secrets

### DIFF
--- a/config/initializers/pay.rb
+++ b/config/initializers/pay.rb
@@ -10,3 +10,7 @@ Pay.setup do |config|
   config.automount_routes = true
   config.routes_path = "/pay"
 end
+
+# Map STRIPE_WEBHOOK_SECRET to what Pay gem expects
+# Pay gem looks for STRIPE_SIGNING_SECRET or credentials[:stripe][:signing_secret]
+ENV["STRIPE_SIGNING_SECRET"] ||= ENV["STRIPE_WEBHOOK_SECRET"] if ENV["STRIPE_WEBHOOK_SECRET"]

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,5 +1,5 @@
 Rails.application.config.after_initialize do
   if defined?(Stripe)
-    Stripe.api_key = Rails.application.credentials.dig(:stripe, :private_key) || ENV["STRIPE_PRIVATE_KEY"]
+    Stripe.api_key = Rails.application.credentials.dig(:stripe, :private_key) || ENV["STRIPE_API_KEY"]
   end
 end


### PR DESCRIPTION
## Summary
- Update `stripe.rb` to use `STRIPE_API_KEY` (matches GCP secret name)
- Add `STRIPE_SIGNING_SECRET` alias for Pay gem webhook verification
  - GCP uses `STRIPE_WEBHOOK_SECRET`, Pay gem expects `STRIPE_SIGNING_SECRET`

## Next Steps
After merging, configure webhook in Stripe Dashboard:
- **Production**: `https://activeagents.ai/pay/webhooks/stripe`
- **Staging**: `https://staging.activeagents.ai/pay/webhooks/stripe`

Events to enable:
- `checkout.session.completed`
- `customer.subscription.created`
- `customer.subscription.updated`
- `customer.subscription.deleted`
- `charge.succeeded`
- `charge.refunded`
- `invoice.payment_failed`
- `invoice.paid`
- `payment_intent.succeeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)