### PR TITLE
fix(ssl): Add multi-domain support for SSL certificates

### DIFF
--- a/docs/issues/2026-04-21-ssl-certificate-mismatch.md
+++ b/docs/issues/2026-04-21-ssl-certificate-mismatch.md
@@ -1,0 +1,70 @@
+# SSL Certificate Mismatch - activeagents.ai
+
+**Date:** 2026-04-21
+**Status:** Fix Ready for Apply
+**Severity:** Production Outage
+
+## Symptom
+
+Visiting `https://activeagents.ai` shows SSL error:
+```
+NET::ERR_CERT_COMMON_NAME_INVALID
+```
+
+Browser reports: "Your connection is not private"
+
+## Root Cause
+
+The SSL certificate was only configured for `staging.activeagents.ai`, but DNS was pointing the apex domain (`activeagents.ai`) to the same load balancer.
+
+**Configuration mismatch:**
+- `dns.tfvars`: `enable_apex_domain = true` (points apex to LB IP)
+- `staging/main.tf`: `lb_domain = "staging.activeagents.ai"` (SSL cert domain)
+
+When users visit `https://activeagents.ai`, the load balancer serves the SSL cert for `staging.activeagents.ai` - causing the certificate/domain mismatch error.
+
+## Fix
+
+Updated Terraform configuration to support multiple domains in the SSL certificate:
+
+1. **modules/load-balancer/variables.tf** - Added `additional_domains` variable
+2. **modules/load-balancer/main.tf** - Updated SSL cert to include additional domains
+3. **terraform/variables.tf** - Added `lb_additional_domains` to root module
+4. **terraform/main.tf** - Pass additional_domains to load balancer module
+5. **environments/staging/variables.tf** - Added `lb_additional_domains` variable
+6. **environments/staging/main.tf** - Auto-include apex domain when `enable_apex_domain = true`
+
+Now when `enable_apex_domain = true`, the SSL certificate includes both:
+- `staging.activeagents.ai`
+- `activeagents.ai`
+
+## Apply Instructions
+
+```bash
+# 1. Navigate to staging environment
+cd terraform/environments/staging
+
+# 2. Initialize (if needed)
+terraform init
+
+# 3. Plan the changes
+terraform plan -var-file=dns.tfvars -var="image=<current-image>" -var="project_id=activeagent-pro"
+
+# 4. Apply (this will recreate the SSL certificate)
+terraform apply -var-file=dns.tfvars -var="image=<current-image>" -var="project_id=activeagent-pro"
+```
+
+**Note:** Google-managed SSL certificates take 15-60 minutes to provision. The site will remain inaccessible until the new cert is active.
+
+## Verification
+
+After applying, verify:
+1. `gcloud compute ssl-certificates describe activeagents-staging-cert --global` shows both domains
+2. `curl -I https://activeagents.ai` returns 200 (may take time for cert propagation)
+3. Browser shows valid certificate for both domains
+
+## Future Considerations
+
+- Consider separate production environment with dedicated load balancer and SSL cert
+- Production should have its own Terraform workspace (`environments/production/`)
+- SSL cert for production: `activeagents.ai` and `www.activeagents.ai`

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -47,9 +47,11 @@ module "activeagents" {
 
   # Load Balancer for public access (bypasses org policy restrictions)
   # NOTE: IAP is configured manually via gcloud (see modules/load-balancer/main.tf)
-  enable_load_balancer = var.enable_load_balancer
-  lb_domain            = var.enable_dns ? "staging.${var.dns_domain}" : var.lb_domain
-  enable_cdn           = var.enable_cdn
+  enable_load_balancer   = var.enable_load_balancer
+  lb_domain              = var.enable_dns ? "staging.${var.dns_domain}" : var.lb_domain
+  # Include apex domain in SSL cert when enable_apex_domain is true
+  lb_additional_domains  = var.enable_apex_domain ? [var.dns_domain] : var.lb_additional_domains
+  enable_cdn             = var.enable_cdn
 
   # DNS configuration
   enable_dns = var.enable_dns

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -51,6 +51,12 @@ variable "lb_domain" {
   default     = null  # Will use IP address until domain is configured
 }
 
+variable "lb_additional_domains" {
+  description = "Additional domains to include in the SSL certificate (e.g., apex domain)"
+  type        = list(string)
+  default     = []
+}
+
 variable "enable_cdn" {
   description = "Enable Cloud CDN for caching static assets (disabled when IAP is used)"
   type        = bool

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -225,6 +225,7 @@ module "load_balancer" {
   name                   = "activeagents-${var.environment}"
   cloud_run_service_name = module.cloud_run.service_name
   domain                 = var.lb_domain
+  additional_domains     = var.lb_additional_domains
   enable_cdn             = var.enable_cdn
   enable_http_redirect   = true
 

--- a/terraform/modules/load-balancer/main.tf
+++ b/terraform/modules/load-balancer/main.tf
@@ -75,13 +75,14 @@ resource "google_compute_url_map" "default" {
 }
 
 # Managed SSL certificate (optional, for custom domain)
+# Supports primary domain plus additional domains (e.g., apex + staging)
 resource "google_compute_managed_ssl_certificate" "default" {
   count   = var.domain != null ? 1 : 0
   project = var.project_id
   name    = "${var.name}-cert"
 
   managed {
-    domains = [var.domain]
+    domains = concat([var.domain], var.additional_domains)
   }
 }
 

--- a/terraform/modules/load-balancer/variables.tf
+++ b/terraform/modules/load-balancer/variables.tf
@@ -19,9 +19,15 @@ variable "cloud_run_service_name" {
 }
 
 variable "domain" {
-  description = "Custom domain for SSL certificate (optional)"
+  description = "Primary custom domain for SSL certificate (optional)"
   type        = string
   default     = null
+}
+
+variable "additional_domains" {
+  description = "Additional domains to include in the SSL certificate (e.g., apex domain)"
+  type        = list(string)
+  default     = []
 }
 
 variable "enable_cdn" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -134,6 +134,12 @@ variable "lb_domain" {
   default     = null
 }
 
+variable "lb_additional_domains" {
+  description = "Additional domains to include in the SSL certificate (e.g., apex domain)"
+  type        = list(string)
+  default     = []
+}
+
 variable "enable_cdn" {
   description = "Enable Cloud CDN for caching static assets (disable if using IAP)"
   type        = bool


### PR DESCRIPTION
## Summary

- Fixes SSL certificate mismatch causing `NET::ERR_CERT_COMMON_NAME_INVALID` on `activeagents.ai`
- Added `additional_domains` support to load-balancer module
- When `enable_apex_domain=true`, SSL cert now includes both `staging.activeagents.ai` and `activeagents.ai`

## Root Cause

The SSL certificate was only configured for `staging.activeagents.ai`, but DNS (`dns.tfvars` with `enable_apex_domain = true`) was pointing the apex domain to the same load balancer IP.

## Changes

| File | Change |
|------|--------|
| `modules/load-balancer/variables.tf` | Added `additional_domains` variable |
| `modules/load-balancer/main.tf` | SSL cert now includes additional domains |
| `terraform/variables.tf` | Added `lb_additional_domains` to root |
| `terraform/main.tf` | Pass additional_domains to LB module |
| `environments/staging/*` | Auto-include apex when enabled |

## Test plan

- [ ] Run `terraform plan` in staging environment
- [ ] Verify plan shows SSL cert being replaced with new domains
- [ ] Apply and wait 15-60 min for Google-managed cert provisioning
- [ ] Test `https://activeagents.ai` in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)