### PR TITLE
chore(ci): Upgrade Terraform to 1.10.0

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.10.0
 
       - name: Determine image to deploy
         id: image

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.10.0
           terraform_wrapper: false  # Required for terraform output to work correctly
 
       - name: Terraform Init


### PR DESCRIPTION
## Summary

Fixes deployment failures caused by HashiCorp GPG key expiration.

## Error
```
Error while installing hashicorp/google v5.45.2: error checking signature: openpgp: key expired
```

## Fix

Upgraded Terraform from 1.6.0 to 1.10.0 in both staging and production workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)