### PR TITLE
fix(terraform): Use existing SSL certificate to prevent deployment breakage

### DIFF
--- a/terraform/environments/staging/dns.tfvars
+++ b/terraform/environments/staging/dns.tfvars
@@ -5,6 +5,11 @@
 # Set to true to switch activeagents.ai from Framer to Cloud Run
 enable_apex_domain = true
 
+# Use existing SSL certificate (already provisioned and active)
+# This avoids the 15-60 min provisioning delay when creating new certs
+# Certificate covers: activeagents.ai, www.activeagents.ai, staging.activeagents.ai
+lb_existing_ssl_cert_name = "activeagents-all-domains-cert"
+
 # Framer website A records (apex domain) - IGNORED when enable_apex_domain = true
 # Updated 2026-02-24 - IPs from Framer custom domain settings
 framer_ips = [

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -47,11 +47,13 @@ module "activeagents" {
 
   # Load Balancer for public access (bypasses org policy restrictions)
   # NOTE: IAP is configured manually via gcloud (see modules/load-balancer/main.tf)
-  enable_load_balancer   = var.enable_load_balancer
-  lb_domain              = var.enable_dns ? "staging.${var.dns_domain}" : var.lb_domain
-  # Include apex domain in SSL cert when enable_apex_domain is true
-  lb_additional_domains  = var.enable_apex_domain ? [var.dns_domain] : var.lb_additional_domains
-  enable_cdn             = var.enable_cdn
+  enable_load_balancer      = var.enable_load_balancer
+  lb_domain                 = var.lb_existing_ssl_cert_name == null ? (var.enable_dns ? "staging.${var.dns_domain}" : var.lb_domain) : null
+  # Include apex domain in SSL cert when enable_apex_domain is true (only if not using existing cert)
+  lb_additional_domains     = var.lb_existing_ssl_cert_name == null && var.enable_apex_domain ? [var.dns_domain] : var.lb_additional_domains
+  # Use existing SSL cert if specified (avoids provisioning delays)
+  lb_existing_ssl_cert_name = var.lb_existing_ssl_cert_name
+  enable_cdn                = var.enable_cdn
 
   # DNS configuration
   enable_dns = var.enable_dns

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -57,6 +57,12 @@ variable "lb_additional_domains" {
   default     = []
 }
 
+variable "lb_existing_ssl_cert_name" {
+  description = "Name of an existing SSL certificate to use instead of creating a new one"
+  type        = string
+  default     = null
+}
+
 variable "enable_cdn" {
   description = "Enable Cloud CDN for caching static assets (disabled when IAP is used)"
   type        = bool

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -226,6 +226,7 @@ module "load_balancer" {
   cloud_run_service_name = module.cloud_run.service_name
   domain                 = var.lb_domain
   additional_domains     = var.lb_additional_domains
+  existing_ssl_cert_name = var.lb_existing_ssl_cert_name
   enable_cdn             = var.enable_cdn
   enable_http_redirect   = true
 

--- a/terraform/modules/load-balancer/main.tf
+++ b/terraform/modules/load-balancer/main.tf
@@ -76,8 +76,9 @@ resource "google_compute_url_map" "default" {
 
 # Managed SSL certificate (optional, for custom domain)
 # Supports primary domain plus additional domains (e.g., apex + staging)
+# Skip creation if using an existing certificate
 resource "google_compute_managed_ssl_certificate" "default" {
-  count   = var.domain != null ? 1 : 0
+  count   = var.domain != null && var.existing_ssl_cert_name == null ? 1 : 0
   project = var.project_id
   name    = "${var.name}-cert"
 
@@ -86,18 +87,32 @@ resource "google_compute_managed_ssl_certificate" "default" {
   }
 }
 
-# HTTPS proxy (only when domain is configured)
+# Data source for existing SSL certificate (if specified)
+data "google_compute_ssl_certificate" "existing" {
+  count   = var.existing_ssl_cert_name != null ? 1 : 0
+  project = var.project_id
+  name    = var.existing_ssl_cert_name
+}
+
+# Local to determine which cert to use
+locals {
+  ssl_certificate_id = var.existing_ssl_cert_name != null ? data.google_compute_ssl_certificate.existing[0].id : (
+    var.domain != null ? google_compute_managed_ssl_certificate.default[0].id : null
+  )
+}
+
+# HTTPS proxy (only when domain is configured or existing cert is provided)
 resource "google_compute_target_https_proxy" "default" {
-  count            = var.domain != null ? 1 : 0
+  count            = var.domain != null || var.existing_ssl_cert_name != null ? 1 : 0
   project          = var.project_id
   name             = "${var.name}-https-proxy"
   url_map          = google_compute_url_map.default.id
-  ssl_certificates = [google_compute_managed_ssl_certificate.default[0].id]
+  ssl_certificates = [local.ssl_certificate_id]
 }
 
-# HTTPS forwarding rule (only when domain is configured)
+# HTTPS forwarding rule (only when domain or existing cert is configured)
 resource "google_compute_global_forwarding_rule" "https" {
-  count                 = var.domain != null ? 1 : 0
+  count                 = var.domain != null || var.existing_ssl_cert_name != null ? 1 : 0
   project               = var.project_id
   name                  = "${var.name}-https"
   target                = google_compute_target_https_proxy.default[0].id
@@ -113,9 +128,9 @@ resource "google_compute_target_http_proxy" "default" {
   url_map = google_compute_url_map.default.id
 }
 
-# HTTP forwarding rule (for direct HTTP access when no domain)
+# HTTP forwarding rule (for direct HTTP access when no domain and no existing cert)
 resource "google_compute_global_forwarding_rule" "http_direct" {
-  count                 = var.domain == null ? 1 : 0
+  count                 = var.domain == null && var.existing_ssl_cert_name == null ? 1 : 0
   project               = var.project_id
   name                  = "${var.name}-http-direct"
   target                = google_compute_target_http_proxy.default.id
@@ -130,9 +145,9 @@ resource "google_compute_global_address" "default" {
   name    = "${var.name}-ip"
 }
 
-# HTTP to HTTPS redirect (only when domain is configured and redirect enabled)
+# HTTP to HTTPS redirect (only when domain or existing cert is configured and redirect enabled)
 resource "google_compute_url_map" "http_redirect" {
-  count   = var.domain != null && var.enable_http_redirect ? 1 : 0
+  count   = (var.domain != null || var.existing_ssl_cert_name != null) && var.enable_http_redirect ? 1 : 0
   project = var.project_id
   name    = "${var.name}-http-redirect"
 
@@ -144,14 +159,14 @@ resource "google_compute_url_map" "http_redirect" {
 }
 
 resource "google_compute_target_http_proxy" "http_redirect" {
-  count   = var.domain != null && var.enable_http_redirect ? 1 : 0
+  count   = (var.domain != null || var.existing_ssl_cert_name != null) && var.enable_http_redirect ? 1 : 0
   project = var.project_id
   name    = "${var.name}-http-proxy"
   url_map = google_compute_url_map.http_redirect[0].id
 }
 
 resource "google_compute_global_forwarding_rule" "http_redirect" {
-  count                 = var.domain != null && var.enable_http_redirect ? 1 : 0
+  count                 = (var.domain != null || var.existing_ssl_cert_name != null) && var.enable_http_redirect ? 1 : 0
   project               = var.project_id
   name                  = "${var.name}-http"
   target                = google_compute_target_http_proxy.http_redirect[0].id

--- a/terraform/modules/load-balancer/outputs.tf
+++ b/terraform/modules/load-balancer/outputs.tf
@@ -5,7 +5,9 @@ output "ip_address" {
 
 output "url" {
   description = "The public URL of the load balancer (HTTPS if domain configured, HTTP otherwise)"
-  value       = var.domain != null ? "https://${var.domain}" : "http://${google_compute_global_address.default.address}"
+  value       = var.domain != null ? "https://${var.domain}" : (
+    var.existing_ssl_cert_name != null ? "https://${google_compute_global_address.default.address}" : "http://${google_compute_global_address.default.address}"
+  )
 }
 
 output "backend_service_name" {
@@ -14,6 +16,6 @@ output "backend_service_name" {
 }
 
 output "uses_https" {
-  description = "Whether the load balancer is configured with HTTPS (requires domain)"
-  value       = var.domain != null
+  description = "Whether the load balancer is configured with HTTPS (requires domain or existing cert)"
+  value       = var.domain != null || var.existing_ssl_cert_name != null
 }

--- a/terraform/modules/load-balancer/variables.tf
+++ b/terraform/modules/load-balancer/variables.tf
@@ -30,6 +30,12 @@ variable "additional_domains" {
   default     = []
 }
 
+variable "existing_ssl_cert_name" {
+  description = "Name of an existing SSL certificate to use instead of creating a new one. Takes precedence over domain/additional_domains."
+  type        = string
+  default     = null
+}
+
 variable "enable_cdn" {
   description = "Enable Cloud CDN for caching"
   type        = bool

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -140,6 +140,12 @@ variable "lb_additional_domains" {
   default     = []
 }
 
+variable "lb_existing_ssl_cert_name" {
+  description = "Name of an existing SSL certificate to use instead of creating a new one"
+  type        = string
+  default     = null
+}
+
 variable "enable_cdn" {
   description = "Enable Cloud CDN for caching static assets (disable if using IAP)"
   type        = bool


### PR DESCRIPTION
## Summary

- Add support for using pre-provisioned SSL certificates in the load-balancer module
- Configure staging to use `activeagents-all-domains-cert` which is already ACTIVE
- Prevents Terraform from creating new certificates that take 15-60 minutes to provision

## Problem

The previous deployment created a new SSL certificate (`activeagents-staging-cert`) which was in PROVISIONING state, causing the site to go down. The HTTPS proxy was pointing to this non-ready certificate instead of the already-active `activeagents-all-domains-cert`.

## Changes

- Add `existing_ssl_cert_name` variable to load-balancer module
- Add data source to reference existing GCP SSL certificate
- Update HTTPS proxy logic to prefer existing cert when specified
- Set `lb_existing_ssl_cert_name = "activeagents-all-domains-cert"` in staging tfvars

## Certificate Status

The `activeagents-all-domains-cert` is already ACTIVE and covers:
- activeagents.ai
- www.activeagents.ai
- staging.activeagents.ai

## Test plan

- [ ] Merge PR triggers staging deployment
- [ ] Terraform uses existing SSL cert instead of creating new one
- [ ] Site is accessible at https://activeagents.ai and https://staging.activeagents.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)