### PR TITLE
fix(deploy): real migrate job; web container boots straight to the server

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -202,12 +202,14 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
+      # The migrate job is terraform-managed (modules/cloud-run) and updated
+      # to the new image by the deploy step above. Failures fail the
+      # pipeline — no silent skip.
       - name: Run database migrations
         run: |
           gcloud run jobs execute activeagents-staging-migrate \
             --region=${{ env.REGION }} \
-            --wait \
-            || echo "Migration job may not exist yet, skipping..."
+            --wait
 
   smoke-test:
     needs: [deploy, migrate]

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -6,8 +6,11 @@ if [ -z "${LD_PRELOAD+x}" ]; then
     export LD_PRELOAD
 fi
 
-# If running the rails server then create or migrate existing database
-if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+# If running the rails server then create or migrate existing database.
+# Deploys set SKIP_DB_PREPARE=true and run migrations through the dedicated
+# Cloud Run migrate job instead, so the web container boots straight to the
+# server and stays inside the startup-probe window.
+if [ -z "${SKIP_DB_PREPARE}" ] && [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare
 fi
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -179,6 +179,9 @@ module "cloud_run" {
     RAILS_LOG_TO_STDOUT    = "true"
     RAILS_SERVE_STATIC_FILES = "true"
     SOLID_QUEUE_IN_PUMA    = "true"
+    # Migrations run via the dedicated Cloud Run migrate job; the web
+    # container boots straight to the server (see bin/docker-entrypoint)
+    SKIP_DB_PREPARE        = "true"
     DB_HOST                = "/cloudsql/${module.cloud_sql.connection_name}"
     DB_NAME                = module.cloud_sql.database_name
     DB_USER                = module.cloud_sql.database_user

--- a/terraform/modules/cloud-run/main.tf
+++ b/terraform/modules/cloud-run/main.tf
@@ -114,6 +114,80 @@ resource "google_cloud_run_v2_service" "main" {
   }
 }
 
+# Database migration job — executed by the deploy pipeline after each image
+# rollout (`gcloud run jobs execute activeagents-<env>-migrate --wait`).
+# Runs db:prepare with the same image/env/Cloud SQL wiring as the service.
+# The web service itself skips db:prepare at boot (SKIP_DB_PREPARE env) so
+# container startup goes straight to the app server instead of spending the
+# startup-probe window on a second Rails boot plus migrations.
+resource "google_cloud_run_v2_job" "migrate" {
+  project  = var.project_id
+  name     = "activeagents-${var.environment}-migrate"
+  location = var.region
+
+  template {
+    template {
+      service_account = var.service_account
+
+      vpc_access {
+        connector = var.vpc_connector_id
+        egress    = "PRIVATE_RANGES_ONLY"
+      }
+
+      containers {
+        image   = var.image
+        command = ["./bin/rails"]
+        args    = ["db:prepare"]
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "1Gi"
+          }
+        }
+
+        dynamic "env" {
+          for_each = var.env_vars
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+
+        dynamic "env" {
+          for_each = var.secret_env_vars
+          content {
+            name = env.key
+            value_source {
+              secret_key_ref {
+                secret  = env.value
+                version = "latest"
+              }
+            }
+          }
+        }
+
+        volume_mounts {
+          name       = "cloudsql"
+          mount_path = "/cloudsql"
+        }
+      }
+
+      volumes {
+        name = "cloudsql"
+        cloud_sql_instance {
+          instances = [var.cloud_sql_connection]
+        }
+      }
+
+      timeout     = "900s"
+      max_retries = 1
+    }
+  }
+
+  labels = var.labels
+}
+
 # Allow unauthenticated access (public web app)
 # Note: This may fail if GCP org policy restricts public access
 # In that case, set allow_public_access = false


### PR DESCRIPTION
## Why

The staging deploy ([run 29466065699](https://github.com/activeagents/activeagents/actions/runs/29466065699)) failed at the Cloud Run rollout: the new revision missed its startup probe. Two compounding causes:

- The container entrypoint runs `db:prepare` before the server — a full second Rails boot plus, this time, the first-ever run of ~10 pending migrations over the Cloud SQL socket, all inside the probe window.
- The pipeline's "Run database migrations" step has been **silently skipping forever**: the `activeagents-staging-migrate` Cloud Run job it executes was never created anywhere.

The previous healthy revision keeps serving throughout — the site never went down.

## What

- **modules/cloud-run**: new terraform-managed `google_cloud_run_v2_job` migrate job (same image/env/service account/Cloud SQL wiring as the service; `rails db:prepare`, 15-min timeout) — created for both environments, matching the job names both workflows already execute.
- **bin/docker-entrypoint**: skips `db:prepare` when `SKIP_DB_PREPARE` is set; the service env now sets it, so the web container boots straight to the app server.
- **deploy-staging.yml**: the migrate step's "job may not exist yet, skipping" fallback is removed — migration failures now fail the pipeline loudly (production's step already did).

## Verification

- Local production-mode reproduction: loaded the pre-merge (April) schema, ran the new migrations (all clean), booted the server with `SOLID_QUEUE_IN_PUMA=true` — `/up` returns 200.
- `terraform validate` green on root, staging, and production.
- Rollout order note: the new revision briefly serves on the pre-migration schema (boots fine — verified) until the migrate job runs in the next pipeline step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5

---
_Generated by [Claude Code](https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5)_