### PR TITLE
fix(migrations): drift-proof the new migrations; surface migrate job logs in CI

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -204,12 +204,24 @@ jobs:
 
       # The migrate job is terraform-managed (modules/cloud-run) and updated
       # to the new image by the deploy step above. Failures fail the
-      # pipeline — no silent skip.
+      # pipeline — no silent skip — and dump the job's logs so the actual
+      # Rails error is visible right here in CI.
       - name: Run database migrations
         run: |
           gcloud run jobs execute activeagents-staging-migrate \
             --region=${{ env.REGION }} \
-            --wait
+            --wait \
+          || {
+            echo "--- migrate job logs (last hour) ---"
+            gcloud logging read \
+              'resource.type="cloud_run_job" AND resource.labels.job_name="activeagents-staging-migrate"' \
+              --project=${{ env.PROJECT_ID }} \
+              --freshness=1h \
+              --limit=200 \
+              --order=asc \
+              --format="value(textPayload)" || true
+            exit 1
+          }
 
   smoke-test:
     needs: [deploy, migrate]

--- a/db/migrate/20260714000001_align_telemetry_traces_with_active_agent.rb
+++ b/db/migrate/20260714000001_align_telemetry_traces_with_active_agent.rb
@@ -53,6 +53,26 @@ class AlignTelemetryTracesWithActiveAgent < ActiveRecord::Migration[8.2]
       add_index TABLE, :agent_class
     end
 
+    # The renamed table may predate some columns (staging drift) — add any
+    # that are missing before touching their defaults.
+    {
+      spans: [ :jsonb, { default: [] } ],
+      resource_attributes: [ :jsonb, { default: {} } ],
+      sdk_info: [ :jsonb, { default: {} } ],
+      total_duration_ms: [ :decimal, {} ],
+      total_input_tokens: [ :integer, { default: 0 } ],
+      total_output_tokens: [ :integer, { default: 0 } ],
+      total_thinking_tokens: [ :integer, { default: 0 } ],
+      status: [ :string, { default: "UNSET" } ],
+      agent_class: [ :string, {} ],
+      agent_action: [ :string, {} ],
+      error_message: [ :text, {} ],
+      service_name: [ :string, {} ],
+      environment: [ :string, {} ]
+    }.each do |column, (type, options)|
+      add_column TABLE, column, type, if_not_exists: true, **options
+    end
+
     # Defaults expected by ActiveAgent::TelemetryTrace.create_from_payload
     change_column_default TABLE, :spans, []
     change_column_default TABLE, :resource_attributes, {}
@@ -62,7 +82,7 @@ class AlignTelemetryTracesWithActiveAgent < ActiveRecord::Migration[8.2]
     change_column_default TABLE, :total_thinking_tokens, 0
     change_column_default TABLE, :status, "UNSET"
 
-    change_column_null TABLE, :timestamp, false, Time.current
+    change_column_null TABLE, :timestamp, false, Time.current if column_exists?(TABLE, :timestamp)
 
     unless index_exists?(TABLE, [ :account_id, :trace_id ], unique: true)
       add_index TABLE, [ :account_id, :trace_id ], unique: true

--- a/db/migrate/20260714000002_create_solid_agent_persistence.rb
+++ b/db/migrate/20260714000002_create_solid_agent_persistence.rb
@@ -9,67 +9,93 @@
 #   the SolidAgent provenance hash (prompt/context/agent checksums)
 # - agent_messages.provenance + content_checksum: populated automatically
 #   by SolidAgent::HasContext when the columns exist (duck-typed)
+#
+# Idempotent by table: environments where an earlier solid_agent generator
+# run already created these tables keep them, and only the missing
+# platform-addition columns are added.
 class CreateSolidAgentPersistence < ActiveRecord::Migration[8.2]
-  def change
-    create_table :agent_contexts do |t|
-      t.references :contextable, polymorphic: true, index: true
-      t.string :agent_name, null: false
-      t.string :action_name, null: false
-      t.text :instructions
-      t.jsonb :options, default: {}
-      t.string :trace_id, index: true
-      t.integer :total_input_tokens, default: 0
-      t.integer :total_output_tokens, default: 0
+  def up
+    unless table_exists?(:agent_contexts)
+      create_table :agent_contexts do |t|
+        t.references :contextable, polymorphic: true, index: true
+        t.string :agent_name, null: false
+        t.string :action_name, null: false
+        t.text :instructions
+        t.jsonb :options, default: {}
+        t.string :trace_id, index: true
+        t.integer :total_input_tokens, default: 0
+        t.integer :total_output_tokens, default: 0
 
-      t.timestamps
+        t.timestamps
+      end
+
+      add_index :agent_contexts, [ :agent_name, :action_name ]
+      add_index :agent_contexts, :created_at
     end
 
-    add_index :agent_contexts, [ :agent_name, :action_name ]
-    add_index :agent_contexts, :created_at
+    unless table_exists?(:agent_messages)
+      create_table :agent_messages do |t|
+        t.references :agent_context, null: false, foreign_key: true, index: true
+        t.string :role, null: false
+        t.text :content
+        t.string :tool_call_id
+        t.string :tool_name
+        t.jsonb :tool_arguments, default: {}
+        t.jsonb :tool_result
+        t.jsonb :attachments, default: []
+        t.jsonb :metadata, default: {}
 
-    create_table :agent_messages do |t|
-      t.references :agent_context, null: false, foreign_key: true, index: true
-      t.string :role, null: false
-      t.text :content
-      t.string :tool_call_id
-      t.string :tool_name
-      t.jsonb :tool_arguments, default: {}
-      t.jsonb :tool_result
-      t.jsonb :attachments, default: []
-      t.jsonb :metadata, default: {}
+        # Platform additions (SolidAgent::HasContext populates these when present)
+        t.jsonb :provenance, default: {}
+        t.string :content_checksum
 
-      # Platform additions (SolidAgent::HasContext populates these when present)
-      t.jsonb :provenance, default: {}
-      t.string :content_checksum
+        t.timestamps
+      end
 
-      t.timestamps
+      add_index :agent_messages, :role
+      add_index :agent_messages, :tool_call_id
+      add_index :agent_messages, [ :agent_context_id, :created_at ]
     end
 
-    add_index :agent_messages, :role
-    add_index :agent_messages, :tool_call_id
-    add_index :agent_messages, [ :agent_context_id, :created_at ]
+    unless table_exists?(:agent_generations)
+      create_table :agent_generations do |t|
+        t.references :agent_context, null: false, foreign_key: true, index: true
+        t.text :content
+        t.string :model
+        t.string :provider
+        t.string :finish_reason
+        t.integer :input_tokens, default: 0
+        t.integer :output_tokens, default: 0
+        t.jsonb :tool_calls, default: []
+        t.jsonb :raw_response
+        t.float :duration_seconds
 
-    create_table :agent_generations do |t|
-      t.references :agent_context, null: false, foreign_key: true, index: true
-      t.text :content
-      t.string :model
-      t.string :provider
-      t.string :finish_reason
-      t.integer :input_tokens, default: 0
-      t.integer :output_tokens, default: 0
-      t.jsonb :tool_calls, default: []
-      t.jsonb :raw_response
-      t.float :duration_seconds
+        # Platform additions: telemetry correlation + provenance
+        t.string :trace_id, index: true
+        t.jsonb :provenance, default: {}
 
-      # Platform additions: telemetry correlation + provenance
-      t.string :trace_id, index: true
-      t.jsonb :provenance, default: {}
+        t.timestamps
+      end
 
-      t.timestamps
+      add_index :agent_generations, :model
+      add_index :agent_generations, :finish_reason
+      add_index :agent_generations, [ :agent_context_id, :created_at ]
     end
 
-    add_index :agent_generations, :model
-    add_index :agent_generations, :finish_reason
-    add_index :agent_generations, [ :agent_context_id, :created_at ]
+    # Pre-existing installs (tables created by an earlier solid_agent
+    # generator run) lack the platform-addition columns — add them.
+    add_column :agent_contexts, :trace_id, :string, if_not_exists: true
+    add_column :agent_messages, :provenance, :jsonb, default: {}, if_not_exists: true
+    add_column :agent_messages, :content_checksum, :string, if_not_exists: true
+    add_column :agent_generations, :trace_id, :string, if_not_exists: true
+    add_column :agent_generations, :provenance, :jsonb, default: {}, if_not_exists: true
+    add_index :agent_contexts, :trace_id, if_not_exists: true
+    add_index :agent_generations, :trace_id, if_not_exists: true
+  end
+
+  def down
+    drop_table :agent_generations, if_exists: true
+    drop_table :agent_messages, if_exists: true
+    drop_table :agent_contexts, if_exists: true
   end
 end

--- a/db/migrate/20260715000001_add_cache_and_reasoning_tokens_to_agent_generations.rb
+++ b/db/migrate/20260715000001_add_cache_and_reasoning_tokens_to_agent_generations.rb
@@ -6,7 +6,7 @@
 # Interactions view.
 class AddCacheAndReasoningTokensToAgentGenerations < ActiveRecord::Migration[8.2]
   def change
-    add_column :agent_generations, :cached_tokens, :integer, default: 0
-    add_column :agent_generations, :reasoning_tokens, :integer, default: 0
+    add_column :agent_generations, :cached_tokens, :integer, default: 0, if_not_exists: true
+    add_column :agent_generations, :reasoning_tokens, :integer, default: 0, if_not_exists: true
   end
 end

--- a/db/migrate/20260715000002_create_evaluations.rb
+++ b/db/migrate/20260715000002_create_evaluations.rb
@@ -2,36 +2,46 @@
 
 # Evaluations score an agent's persisted generations (solid_agent's
 # agent_generations) against rule-based criteria and, when a provider is
-# configured, an LLM judge.
+# configured, an LLM judge. Idempotent by table (skips environments where
+# the tables already exist).
 class CreateEvaluations < ActiveRecord::Migration[8.2]
-  def change
-    create_table :evaluations do |t|
-      t.references :agent, null: false, foreign_key: true
-      t.string :name, null: false
-      t.string :judge_kind, null: false, default: "rules" # rules | llm
-      t.string :judge_model
-      t.jsonb :criteria, null: false, default: []
-      t.integer :sample_size, null: false, default: 20
+  def up
+    unless table_exists?(:evaluations)
+      create_table :evaluations do |t|
+        t.references :agent, null: false, foreign_key: true
+        t.string :name, null: false
+        t.string :judge_kind, null: false, default: "rules" # rules | llm
+        t.string :judge_model
+        t.jsonb :criteria, null: false, default: []
+        t.integer :sample_size, null: false, default: 20
 
-      t.timestamps
+        t.timestamps
+      end
+
+      add_index :evaluations, [ :agent_id, :name ], unique: true
     end
 
-    add_index :evaluations, [ :agent_id, :name ], unique: true
+    unless table_exists?(:evaluation_runs)
+      create_table :evaluation_runs do |t|
+        t.references :evaluation, null: false, foreign_key: true
+        t.integer :status, null: false, default: 0 # pending/running/complete/failed
+        # { criterion_key => { "score" =>, "min" =>, "max" =>, "passed" =>, "total" => } }
+        t.jsonb :scores, default: {}
+        t.integer :samples_evaluated, default: 0
+        t.integer :samples_passed, default: 0
+        t.text :error_message
+        t.datetime :completed_at
 
-    create_table :evaluation_runs do |t|
-      t.references :evaluation, null: false, foreign_key: true
-      t.integer :status, null: false, default: 0 # pending/running/complete/failed
-      # { criterion_key => { "score" =>, "min" =>, "max" =>, "passed" =>, "total" => } }
-      t.jsonb :scores, default: {}
-      t.integer :samples_evaluated, default: 0
-      t.integer :samples_passed, default: 0
-      t.text :error_message
-      t.datetime :completed_at
+        t.timestamps
+      end
 
-      t.timestamps
+      add_index :evaluation_runs, [ :evaluation_id, :created_at ]
+      add_index :evaluation_runs, :status
     end
+  end
 
-    add_index :evaluation_runs, [ :evaluation_id, :created_at ]
-    add_index :evaluation_runs, :status
+  def down
+    drop_table :evaluation_runs, if_exists: true
+    drop_table :evaluations, if_exists: true
   end
 end

--- a/terraform/modules/cloud-run/main.tf
+++ b/terraform/modules/cloud-run/main.tf
@@ -141,8 +141,9 @@ resource "google_cloud_run_v2_job" "migrate" {
 
         resources {
           limits = {
-            cpu    = "1"
-            memory = "1Gi"
+            # Match the service: a full Rails boot needs the same headroom
+            cpu    = var.cpu
+            memory = var.memory
           }
         }
 


### PR DESCRIPTION
## Why

[Run 30414928695](https://github.com/activeagents/activeagents/actions/runs/30414928695): the deploy step now succeeds (PR #91's boot fix worked — the new revision serves), but the **migrate job failed** against the real staging database while the same migrations pass on a clean schema. Reproduced locally by loading the pre-merge schema **plus** old-shape solid_agent tables from an earlier generator run: `create_table ... if_not_exists:` skips the table but still creates inline indexes against columns the old shape lacks (`PG::UndefinedColumn: trace_id`). The first failed rollout's crashlooping containers also each ran `db:prepare`, so `schema_migrations` on staging may sit anywhere in the new range — everything must be idempotent.

## What

- `CreateSolidAgentPersistence` / `CreateEvaluations`: each `create_table` + its indexes wrapped in `table_exists?`; pre-existing tables get the missing platform columns (`trace_id`, `provenance`, `content_checksum`) added; explicit `up`/`down`.
- `AlignTelemetryTracesWithActiveAgent`: adds any columns the renamed legacy table is missing before touching their defaults; guarded `change_column_null`.
- `AddCacheAndReasoningTokens`: `if_not_exists`.
- Migrate Cloud Run job now gets the service's cpu/memory (full Rails boot in 1Gi risked OOM).
- Staging workflow dumps the migrate job's Cloud Logging output into CI on failure — the actual Rails error becomes visible in the pipeline.

## Verification

- Local: pre-merge schema + simulated drift (old-shape solid_agent tables) → all four migrations green, platform columns present with correct defaults, **re-run is a no-op**.
- Full platform suite green (188 runs), terraform validate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5

---
_Generated by [Claude Code](https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5)_