### PR TITLE
fix(deploy): narrow migrate job to db:migrate:primary; CI log visibility

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,6 +79,15 @@ resource "google_project_iam_member" "cloud_run_cloudsql_client" {
   member  = "serviceAccount:${google_service_account.cloud_run.email}"
 }
 
+# Grant the CI service account log read access so the deploy pipeline can
+# surface Cloud Run job output (e.g. migrate job failures) in CI logs
+resource "google_project_iam_member" "ci_logging_viewer" {
+  count   = var.ci_service_account != null ? 1 : 0
+  project = var.project_id
+  role    = "roles/logging.viewer"
+  member  = "serviceAccount:${var.ci_service_account}"
+}
+
 # Artifact Registry for Docker images
 resource "google_artifact_registry_repository" "activeagents" {
   project       = var.project_id

--- a/terraform/modules/cloud-run/main.tf
+++ b/terraform/modules/cloud-run/main.tf
@@ -136,8 +136,11 @@ resource "google_cloud_run_v2_job" "migrate" {
 
       containers {
         image   = var.image
+        # Migrate only the primary database: the cache/queue schemas are
+        # managed separately and db:prepare's create-if-missing behavior
+        # across all three databases needs privileges the app user may lack
         command = ["./bin/rails"]
-        args    = ["db:prepare"]
+        args    = ["db:migrate:primary"]
 
         resources {
           limits = {


### PR DESCRIPTION
## Why

Second migrate-job failure ([run 30416080491](https://github.com/activeagents/activeagents/actions/runs/30416080491)), still blind: the log-dump failure handler hit `PERMISSION_DENIED` — the CI service account can't read Cloud Logging, so the job's actual Rails error never reached the pipeline output.

## What

- Grant the CI service account `roles/logging.viewer` (terraform-managed like the existing project IAM grants) so the failure handler can print the migrate job's logs into CI.
- The migrate job runs `db:migrate:primary` instead of `db:prepare`: only the primary database has pending migrations, and `db:prepare`'s create-if-missing pass over the cache/queue databases needs privileges the Cloud SQL app user may not have — a plausible cause of the failure, and needless surface area regardless.

Either this run goes green (if the cache/queue theory is right), or the next failure prints the real error in CI and the loop stops being blind.

## Verification

`db:migrate:primary` verified locally against the production-mode drift replica; `terraform validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5

---
_Generated by [Claude Code](https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5)_