### PR TITLE
fix(migrations): create the schema-only accounts columns staging never got

### DIFF
--- a/db/migrate/20260714000001_align_telemetry_traces_with_active_agent.rb
+++ b/db/migrate/20260714000001_align_telemetry_traces_with_active_agent.rb
@@ -94,6 +94,18 @@ class AlignTelemetryTracesWithActiveAgent < ActiveRecord::Migration[8.2]
       add_index TABLE, :status
     end
 
+    # accounts.telemetry_api_key entered schema.rb in April without a
+    # migration ever being written, so schema-loaded databases have these
+    # while migration-evolved ones (staging) don't. Same defensive guards
+    # for the usage-tracking columns the Account model reads at runtime.
+    add_column :accounts, :telemetry_api_key, :string, if_not_exists: true
+    unless index_exists?(:accounts, :telemetry_api_key, unique: true)
+      add_index :accounts, :telemetry_api_key, unique: true
+    end
+    add_column :accounts, :agent_runs_this_period, :integer, default: 0, null: false, if_not_exists: true
+    add_column :accounts, :agent_runs_limit, :integer, default: 3, null: false, if_not_exists: true
+    add_column :accounts, :usage_period_start, :datetime, if_not_exists: true
+
     # Backfill telemetry API keys for accounts created before the key
     # generation callback existed.
     Account.reset_column_information


### PR DESCRIPTION
## Why

With migrate-job logs now visible in CI ([run 30417143207](https://github.com/activeagents/activeagents/actions/runs/30417143207)), the real error surfaced: `PG::UndefinedColumn: accounts.telemetry_api_key` at the align migration's backfill.

Root cause: `telemetry_api_key` (+ unique index) were added **directly to db/schema.rb** in April (18de797) without a migration ever being written. Every schema-loaded database — dev, test, CI, and all my local repros — has the column; the real staging database, which evolves only through migrations, does not. The same run confirmed staging also never had the `telemetry_traces` table (the migration's create branch already handles that).

## What

`AlignTelemetryTracesWithActiveAgent` now creates, guarded by `if_not_exists`, everything the new code reads on `accounts` — `telemetry_api_key` + unique index, `agent_runs_this_period`, `agent_runs_limit`, `usage_period_start` — before running the key backfill.

## Verification

Faithful staging replica (pre-merge schema **minus** the schema-only drift, with a live account row): all four migrations green, key backfilled for the existing account, re-run is a no-op. Full platform suite green (188 runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5

---
_Generated by [Claude Code](https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5)_