### PR TITLE
fix(deploy): smoke-test against the staging hostname, not the bare LB IP

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -155,6 +155,14 @@ jobs:
             PUBLIC_URL="$CLOUD_RUN_URL"
           fi
 
+          # Prefer the staging hostname over the raw LB IP: TLS to a bare IP
+          # can never pass SNI certificate validation, which made every
+          # smoke test against https://<ip> fail with connection errors.
+          STAGING_DOMAIN=$(terraform output -raw staging_domain 2>/dev/null || echo "")
+          if [ -n "$STAGING_DOMAIN" ] && [ "$STAGING_DOMAIN" != "null" ]; then
+            PUBLIC_URL="https://$STAGING_DOMAIN"
+          fi
+
           echo "Public URL: $PUBLIC_URL"
           echo "url=$PUBLIC_URL" >> $GITHUB_OUTPUT
           echo "cloud_run_url=$CLOUD_RUN_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Why

[Run 30417851581](https://github.com/activeagents/activeagents/actions/runs/30417851581): **deploy ✓, migrate ✓** — the platform is live and migrated. The only red is the smoke test, which curls `https://<lb-ip>/up`; TLS to a bare IP can never pass SNI certificate validation, so every attempt returns a connection error (status 000). This is also why April's deploy run failed at smoke test.

## What

The *Get Service URLs* step prefers `https://<staging_domain>` (terraform output) as the public URL, so the smoke test validates the real, certificate-matched endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5

---
_Generated by [Claude Code](https://claude.ai/code/session_014h5Yw7jE62UyPPAF1h7Mr5)_