### PR TITLE
Extract RubyLLM telemetry into a standalone gem

### DIFF
--- a/docs/integrations/ruby_llm.md
+++ b/docs/integrations/ruby_llm.md
@@ -36,7 +36,7 @@ telemetry:
 
 RubyLLM emits `chat.ruby_llm` and `tool_call.ruby_llm` events through a
 configurable instrumenter. Point it at `ActiveSupport::Notifications` and
-subscribe with the adapter below — a single vendorable file with no
+subscribe with this repo's `active_agents-ruby_llm_telemetry` gem — no
 dependencies beyond ActiveSupport and stdlib.
 
 ```ruby
@@ -119,314 +119,18 @@ from the payload.
 
 ### The adapter
 
+It ships as a gem in this repo (`ruby_llm_telemetry/`), so nothing is
+vendored into the consuming app:
+
 ```ruby
-# lib/active_agents/ruby_llm_telemetry.rb
-require "net/http"
-require "json"
-require "securerandom"
-
-module ActiveAgents
-  # Reports RubyLLM chats to an ActiveAgents-compatible trace endpoint
-  # (POST /v1/traces — the wire format ActiveAgent::Telemetry uses).
-  #
-  # Requires RubyLLM.config.instrumenter = ActiveSupport::Notifications.
-  #
-  # One trace per conversation turn: a root span, an llm span covering the
-  # whole provider loop, and a tool span per tool_call.ruby_llm event.
-  #
-  # RubyLLM emits a chat.ruby_llm event per provider round, and the two
-  # generations of the gem arrange those rounds differently: through 1.x a
-  # tool round recurses inside the enclosing event, while 2.x drives a flat
-  # `step until complete?` loop whose rounds are siblings with tool calls
-  # firing between them. Rounds are therefore accumulated and flushed on the
-  # round that ends the turn — the one that errors or answers without
-  # requesting tools — which yields the same trace under both arrangements.
-  # Tokens are summed per round from the assistant messages that round added,
-  # so a repeated event-level count is never double counted.
-  #
-  # Tool arguments and results are never sent; error messages are truncated.
-  module RubyLLMTelemetry
-    DEFAULT_ENDPOINT = "https://api.activeagents.ai/v1/traces".freeze
-    AGENT_KEY = :active_agents_ruby_llm_agent
-    STATE_KEY = :active_agents_ruby_llm_state
-    TOOL_STARTED_AT_KEY = :_active_agents_started_at
-    ERROR_MESSAGE_LIMIT = 200
-    # A turn that never reaches a final round (a halted tool call, or an app
-    # driving RubyLLM 2.x's `step` by hand) would otherwise accumulate forever.
-    MAX_TURN_SECONDS = 600
-
-    State = Struct.new(:depth, :started_at, :tool_spans, :rounds, :tokens, :chat_key)
-
-    class << self
-      attr_reader :endpoint, :api_key, :service_name, :environment
-
-      # agent_resolver: optional callable receiving the chat event payload and
-      # returning { name:, action: }, so traffic can be attributed from an
-      # initializer alone; an enclosing with_agent block still wins. RubyLLM
-      # carries no application identity on the payload — neither RubyLLM::Agent
-      # nor an acts_as_chat record reaches the instrumenter — so unattributed
-      # traffic reports as RubyLLM::Chat.
-      def subscribe!(api_key:, endpoint: DEFAULT_ENDPOINT, service_name: nil, environment: nil, agent_resolver: nil, async: true)
-        @api_key = api_key
-        @endpoint = endpoint
-        @service_name = service_name || default_service_name
-        @environment = environment || default_environment
-        @agent_resolver = agent_resolver
-        @async = async
-
-        @subscriptions ||= [
-          ActiveSupport::Notifications.subscribe("chat.ruby_llm", ChatSubscriber.new),
-          ActiveSupport::Notifications.subscribe("tool_call.ruby_llm", ToolCallSubscriber.new)
-        ]
-      end
-
-      def unsubscribe!
-        Array(@subscriptions).each { |subscription| ActiveSupport::Notifications.unsubscribe(subscription) }
-        @subscriptions = nil
-      end
-
-      # Attributes traces inside the block to a named agent/action.
-      def with_agent(name, action: "chat")
-        previous = Thread.current[AGENT_KEY]
-        Thread.current[AGENT_KEY] = { name: name, action: action }
-        yield
-      ensure
-        Thread.current[AGENT_KEY] = previous
-      end
-
-      def state
-        Thread.current[STATE_KEY] ||= State.new(0, nil, [], 0, zero_tokens, nil)
-      end
-
-      def clear_state
-        Thread.current[STATE_KEY] = nil
-      end
-
-      # Reports whatever the current turn has accumulated. Apps that drive
-      # RubyLLM 2.x's `step`/`run_tools` themselves can call this to close a
-      # turn that ends while tool calls are still pending.
-      def flush!(payload = {})
-        turn = Thread.current[STATE_KEY]
-        return if turn.nil? || turn.rounds.zero?
-
-        clear_state
-        report_turn(payload, turn)
-      end
-
-      def begin_round(payload)
-        turn = state
-        if turn.depth.zero?
-          chat_key = payload[:chat].object_id
-          flush! if turn.rounds.positive? && (turn.chat_key != chat_key || turn_expired?(turn))
-          turn = state
-          turn.chat_key = chat_key
-          turn.started_at ||= Time.current
-        end
-        turn.depth += 1
-      end
-
-      def finish_round(payload)
-        turn = state
-        turn.depth -= 1
-        return unless turn.depth.zero?
-
-        turn.rounds += 1
-        accumulate_tokens(turn, payload)
-        flush!(payload) if payload[:exception_object] || !payload[:tool_call]
-      end
-
-      def build_tool_span(payload, started_at, finished_at)
-        error = payload[:exception_object]
-        attributes = { "tool.name" => payload[:tool_name].to_s, "tool.call_id" => payload[:tool_call_id].to_s }
-        attributes.merge!(error_attributes(error)) if error
-
-        {
-          "span_id" => SecureRandom.hex(8),
-          "name" => "tool.#{payload[:tool_name]}",
-          "type" => "tool",
-          "start_time" => started_at.utc.iso8601(6),
-          "end_time" => finished_at.utc.iso8601(6),
-          "duration_ms" => duration_ms(started_at, finished_at),
-          "status" => error ? "ERROR" : "OK",
-          "attributes" => attributes,
-          "tokens" => zero_tokens,
-          "events" => []
-        }
-      end
-
-      private
-
-      def report_turn(payload, turn)
-        agent = Thread.current[AGENT_KEY] || resolve_agent(payload) || { name: "RubyLLM::Chat", action: "chat" }
-        trace_id = SecureRandom.hex(16)
-        root_id = SecureRandom.hex(8)
-        llm_id = SecureRandom.hex(8)
-        started_at = turn.started_at || Time.current
-        finished_at = Time.current
-        error = payload[:exception_object]
-
-        base = {
-          "trace_id" => trace_id,
-          "start_time" => started_at.utc.iso8601(6),
-          "end_time" => finished_at.utc.iso8601(6),
-          "duration_ms" => duration_ms(started_at, finished_at),
-          "status" => error ? "ERROR" : "OK",
-          "events" => []
-        }
-
-        root_attributes = {
-          "agent.class" => agent[:name],
-          "agent.action" => agent[:action],
-          "agent.provider" => payload[:provider].to_s,
-          "agent.model" => payload[:model].to_s
-        }
-        root_attributes.merge!(error_attributes(error)) if error
-
-        root_span = base.merge(
-          "span_id" => root_id, "parent_span_id" => nil,
-          "name" => "#{agent[:name]}.#{agent[:action]}", "type" => "root",
-          "attributes" => root_attributes,
-          "tokens" => zero_tokens
-        )
-
-        llm_span = base.merge(
-          "span_id" => llm_id, "parent_span_id" => root_id,
-          "name" => "llm.generate", "type" => "llm",
-          "attributes" => {
-            "llm.provider" => payload[:provider].to_s,
-            "llm.model" => payload[:model].to_s,
-            "llm.rounds" => turn.rounds,
-            "llm.streaming" => payload[:streaming] || false
-          },
-          "tokens" => turn.tokens
-        )
-
-        tool_spans = turn.tool_spans.map { |span| span.merge("trace_id" => trace_id, "parent_span_id" => llm_id) }
-
-        post_traces(
-          "traces" => [{
-            "trace_id" => trace_id,
-            "service_name" => service_name,
-            "environment" => environment,
-            "timestamp" => finished_at.utc.iso8601(6),
-            "resource_attributes" => {},
-            "spans" => [root_span, llm_span] + tool_spans
-          }],
-          "sdk" => { "name" => "active_agents-ruby_llm", "version" => "1.2", "language" => "ruby", "runtime_version" => RUBY_VERSION }
-        )
-      end
-
-      def turn_expired?(turn)
-        turn.started_at.nil? || (Time.current - turn.started_at) > MAX_TURN_SECONDS
-      end
-
-      def accumulate_tokens(turn, payload)
-        round_tokens = token_totals(payload)
-        turn.tokens = turn.tokens.merge(round_tokens) { |_key, carried, added| carried + added }
-      end
-
-      def resolve_agent(payload)
-        agent = @agent_resolver&.call(payload)
-        return unless agent.is_a?(Hash) && agent[:name].present?
-
-        { name: agent[:name], action: agent[:action] || "chat" }
-      rescue StandardError => e
-        warn "[ActiveAgents::RubyLLMTelemetry] agent_resolver failed: #{e.class}: #{e.message}"
-        nil
-      end
-
-      def default_service_name
-        defined?(Rails) ? Rails.application.class.module_parent_name.underscore : "ruby_llm"
-      end
-
-      def default_environment
-        defined?(Rails) ? Rails.env : ENV.fetch("RACK_ENV", "production")
-      end
-
-      def duration_ms(started_at, finished_at)
-        ((finished_at - started_at) * 1000).round(2)
-      end
-
-      def error_attributes(error)
-        { "error.type" => error.class.name, "error.message" => error.message.to_s.truncate(ERROR_MESSAGE_LIMIT) }
-      end
-
-      def zero_tokens
-        { "input" => 0, "output" => 0, "thinking" => 0, "total" => 0 }
-      end
-
-      def token_totals(payload)
-        initial_count = Array(payload[:input_messages]).size
-        new_messages = Array(payload[:messages_after])[initial_count..] || []
-        assistant_messages = new_messages.select { |message| message.respond_to?(:role) && message.role.to_s == "assistant" }
-
-        tokens = {
-          "input" => sum_tokens(assistant_messages, :input_tokens),
-          "output" => sum_tokens(assistant_messages, :output_tokens),
-          "thinking" => sum_tokens(assistant_messages, :thinking_tokens)
-        }
-        tokens["total"] = tokens.values.sum
-        tokens
-      end
-
-      def sum_tokens(messages, method_name)
-        messages.sum { |message| message.respond_to?(method_name) ? message.public_send(method_name).to_i : 0 }
-      end
-
-      def post_traces(body)
-        return deliver(body) unless @async
-
-        Thread.new { deliver(body) }
-      end
-
-      def deliver(body)
-        uri = URI.parse(endpoint)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.scheme == "https"
-        http.open_timeout = http.read_timeout = 10
-
-        request = Net::HTTP::Post.new(uri.request_uri)
-        request["Content-Type"] = "application/json"
-        request["Authorization"] = "Bearer #{api_key}"
-        request.body = JSON.generate(body)
-        http.request(request)
-      rescue StandardError => e
-        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
-      end
-    end
-
-    # Evented ActiveSupport::Notifications subscriber; finish fires even when
-    # the instrumented block raises, with the exception on the payload.
-    class ChatSubscriber
-      def start(_name, _id, payload)
-        RubyLLMTelemetry.begin_round(payload)
-      rescue StandardError => e
-        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
-      end
-
-      def finish(_name, _id, payload)
-        RubyLLMTelemetry.finish_round(payload)
-      rescue StandardError => e
-        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
-        RubyLLMTelemetry.clear_state
-      end
-    end
-
-    class ToolCallSubscriber
-      def start(_name, _id, payload)
-        payload[TOOL_STARTED_AT_KEY] = Time.current
-      end
-
-      def finish(_name, _id, payload)
-        started_at = payload.delete(TOOL_STARTED_AT_KEY) || Time.current
-        RubyLLMTelemetry.state.tool_spans << RubyLLMTelemetry.build_tool_span(payload, started_at, Time.current)
-      rescue StandardError => e
-        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
-      end
-    end
-  end
-end
+# Gemfile
+gem "active_agents-ruby_llm_telemetry",
+    github: "activeagents/activeagents", glob: "ruby_llm_telemetry/*.gemspec"
 ```
+
+Bundler requires it as `active_agents/ruby_llm_telemetry`, so the initializer
+above is the whole integration. Implementation, tests, and the full option
+list live in `ruby_llm_telemetry/README.md`.
 
 Notes:
 
@@ -492,8 +196,8 @@ dashboard.
 
 ## Roadmap note
 
-The right long-term home for this adapter is the activeagent gem itself
-(e.g. `ActiveAgent::Telemetry::Adapters::RubyLLM`, loadable without the
-rest of the framework) so RubyLLM users get a supported, versioned client
-instead of a vendored file. First production consumer: Sparkle's Clara
-admin chat (`combinaut/sparkle`, `lib/active_agents/ruby_llm_telemetry.rb`).
+`ruby_llm_telemetry/` is a self-contained gem so it can be broken out into
+its own repository, or folded into the activeagent gem itself (e.g.
+`ActiveAgent::Telemetry::Adapters::RubyLLM`, loadable without the rest of the
+framework), without changing the consuming app beyond its Gemfile line.
+First production consumer: Sparkle's Clara admin chat (`combinaut/sparkle`).

--- a/docs/integrations/ruby_llm.md
+++ b/docs/integrations/ruby_llm.md
@@ -61,43 +61,70 @@ ActiveAgents::RubyLLMTelemetry.with_agent("SupportBot", action: "respond") do
 end
 ```
 
+### How events map to spans
+
+A chat that runs tools emits **nested** `chat.ruby_llm` events — each tool
+round recurses through `RubyLLM::Chat#complete`, and the outer event's token
+fields repeat the final round's counts. The adapter therefore builds **one
+trace per outermost event**:
+
+- a `root` span named `Agent.action`,
+- a single `llm` span covering the whole provider loop (tools execute inside
+  it — the same shape the dashboard's generation-vs-tools time breakdown
+  expects), with token totals summed from the assistant messages the ask
+  added, so nested rounds are not double counted, and
+- a `tool` span per `tool_call.ruby_llm` event, with real start/end times
+  and `tool.name` / `tool.call_id` attributes, parented under the llm span.
+
+Tool arguments and results are deliberately never sent, and error messages
+are truncated — safe defaults for apps whose tool traffic may contain
+sensitive data.
+
 ### The adapter
 
 ```ruby
 # lib/active_agents/ruby_llm_telemetry.rb
-# frozen_string_literal: true
-
 require "net/http"
 require "json"
 require "securerandom"
 
 module ActiveAgents
   # Reports RubyLLM chat completions to an ActiveAgents-compatible trace
-  # endpoint (the same wire format ActiveAgent::Telemetry uses).
+  # endpoint (POST /v1/traces — the wire format ActiveAgent::Telemetry uses).
   #
-  # Subscribes to RubyLLM's instrumentation events; requires
-  # RubyLLM.config.instrumenter = ActiveSupport::Notifications.
+  # Requires RubyLLM.config.instrumenter = ActiveSupport::Notifications.
   module RubyLLMTelemetry
     DEFAULT_ENDPOINT = "https://api.activeagents.ai/v1/traces"
     AGENT_KEY = :active_agents_ruby_llm_agent
+    STATE_KEY = :active_agents_ruby_llm_state
+    TOOL_STARTED_AT_KEY = :_active_agents_started_at
+    ERROR_MESSAGE_LIMIT = 200
+
+    State = Struct.new(:depth, :started_at, :tool_spans, :rounds)
 
     class << self
       attr_reader :endpoint, :api_key, :service_name, :environment
 
-      def subscribe!(api_key:, endpoint: DEFAULT_ENDPOINT, service_name: nil, environment: nil)
+      def subscribe!(api_key:, endpoint: DEFAULT_ENDPOINT, service_name: nil, environment: nil, async: true)
         @api_key = api_key
         @endpoint = endpoint
-        @service_name = service_name || (defined?(Rails) ? Rails.application.class.module_parent_name.underscore : "ruby_llm")
-        @environment = environment || (defined?(Rails) ? Rails.env : ENV.fetch("RACK_ENV", "production"))
+        @service_name = service_name || default_service_name
+        @environment = environment || default_environment
+        @async = async
 
-        ActiveSupport::Notifications.subscribe("chat.ruby_llm") do |event|
-          report_chat_event(event)
-        rescue StandardError => e
-          warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
-        end
+        @subscriptions ||= [
+          ActiveSupport::Notifications.subscribe("chat.ruby_llm", ChatSubscriber.new),
+          ActiveSupport::Notifications.subscribe("tool_call.ruby_llm", ToolCallSubscriber.new)
+        ]
       end
 
-      # Attributes traces inside the block to a named agent/action.
+      def unsubscribe!
+        Array(@subscriptions).each { |subscription| ActiveSupport::Notifications.unsubscribe(subscription) }
+        @subscriptions = nil
+      end
+
+      # Attributes traces inside the block to a named agent/action; otherwise
+      # traffic reports as RubyLLM::Chat. Safe to call when not subscribed.
       def with_agent(name, action: "chat")
         previous = Thread.current[AGENT_KEY]
         Thread.current[AGENT_KEY] = { name: name, action: action }
@@ -106,47 +133,58 @@ module ActiveAgents
         Thread.current[AGENT_KEY] = previous
       end
 
-      private
+      def state
+        Thread.current[STATE_KEY] ||= State.new(0, nil, [], 0)
+      end
 
-      def report_chat_event(event)
-        payload = event.payload
-        response = payload[:response]
-        return unless response # streaming interrupted or provider error
+      def clear_state
+        Thread.current[STATE_KEY] = nil
+      end
 
+      def report_chat(payload, started_at, finished_at, tool_spans:, rounds:)
         agent = Thread.current[AGENT_KEY] || { name: "RubyLLM::Chat", action: "chat" }
         trace_id = SecureRandom.hex(16)
         root_id = SecureRandom.hex(8)
-        started_at = Time.now - (event.duration / 1000.0)
-        finished_at = Time.now
+        llm_id = SecureRandom.hex(8)
         error = payload[:exception_object]
 
-        tokens = {
-          "input" => response.respond_to?(:input_tokens) ? response.input_tokens.to_i : 0,
-          "output" => response.respond_to?(:output_tokens) ? response.output_tokens.to_i : 0,
-          "thinking" => 0
-        }
-        tokens["total"] = tokens.values.sum
-
-        root_span = {
-          "span_id" => root_id, "trace_id" => trace_id, "parent_span_id" => nil,
-          "name" => "#{agent[:name]}.#{agent[:action]}", "type" => "root",
-          "start_time" => started_at.utc.iso8601(6), "end_time" => finished_at.utc.iso8601(6),
-          "duration_ms" => event.duration.round(2),
+        base = {
+          "trace_id" => trace_id,
+          "start_time" => started_at.utc.iso8601(6),
+          "end_time" => finished_at.utc.iso8601(6),
+          "duration_ms" => duration_ms(started_at, finished_at),
           "status" => error ? "ERROR" : "OK",
-          "attributes" => {
-            "agent.class" => agent[:name], "agent.action" => agent[:action],
-            "agent.provider" => payload[:provider].to_s, "agent.model" => payload[:model].to_s
-          }.merge(error ? { "error.type" => error.class.name, "error.message" => error.message } : {}),
-          "tokens" => { "input" => 0, "output" => 0, "thinking" => 0, "total" => 0 },
           "events" => []
         }
 
-        llm_span = root_span.merge(
-          "span_id" => SecureRandom.hex(8), "parent_span_id" => root_id,
-          "name" => "llm.generate", "type" => "llm",
-          "attributes" => { "llm.provider" => payload[:provider].to_s, "llm.model" => payload[:model].to_s },
-          "tokens" => tokens
+        root_attributes = {
+          "agent.class" => agent[:name],
+          "agent.action" => agent[:action],
+          "agent.provider" => payload[:provider].to_s,
+          "agent.model" => payload[:model].to_s
+        }
+        root_attributes.merge!(error_attributes(error)) if error
+
+        root_span = base.merge(
+          "span_id" => root_id, "parent_span_id" => nil,
+          "name" => "#{agent[:name]}.#{agent[:action]}", "type" => "root",
+          "attributes" => root_attributes,
+          "tokens" => zero_tokens
         )
+
+        llm_span = base.merge(
+          "span_id" => llm_id, "parent_span_id" => root_id,
+          "name" => "llm.generate", "type" => "llm",
+          "attributes" => {
+            "llm.provider" => payload[:provider].to_s,
+            "llm.model" => payload[:model].to_s,
+            "llm.rounds" => rounds,
+            "llm.streaming" => payload[:streaming] || false
+          },
+          "tokens" => token_totals(payload)
+        )
+
+        child_tool_spans = tool_spans.map { |tool_span| tool_span.merge("trace_id" => trace_id, "parent_span_id" => llm_id) }
 
         post_traces(
           "traces" => [ {
@@ -155,13 +193,81 @@ module ActiveAgents
             "environment" => environment,
             "timestamp" => finished_at.utc.iso8601(6),
             "resource_attributes" => {},
-            "spans" => [ root_span, llm_span ]
+            "spans" => [ root_span, llm_span ] + child_tool_spans
           } ],
-          "sdk" => { "name" => "active_agents-ruby_llm", "version" => "1.0", "language" => "ruby", "runtime_version" => RUBY_VERSION }
+          "sdk" => { "name" => "active_agents-ruby_llm", "version" => "1.1", "language" => "ruby", "runtime_version" => RUBY_VERSION }
         )
       end
 
+      def build_tool_span(payload, started_at, finished_at)
+        error = payload[:exception_object]
+        attributes = {
+          "tool.name" => payload[:tool_name].to_s,
+          "tool.call_id" => payload[:tool_call_id].to_s
+        }
+        attributes.merge!(error_attributes(error)) if error
+
+        {
+          "span_id" => SecureRandom.hex(8),
+          "name" => "tool.#{payload[:tool_name]}",
+          "type" => "tool",
+          "start_time" => started_at.utc.iso8601(6),
+          "end_time" => finished_at.utc.iso8601(6),
+          "duration_ms" => duration_ms(started_at, finished_at),
+          "status" => error ? "ERROR" : "OK",
+          "attributes" => attributes,
+          "tokens" => zero_tokens,
+          "events" => []
+        }
+      end
+
+      private
+
+      def default_service_name
+        defined?(Rails) ? Rails.application.class.module_parent_name.underscore : "ruby_llm"
+      end
+
+      def default_environment
+        defined?(Rails) ? Rails.env : ENV.fetch("RACK_ENV", "production")
+      end
+
+      def duration_ms(started_at, finished_at)
+        ((finished_at - started_at) * 1000).round(2)
+      end
+
+      def error_attributes(error)
+        { "error.type" => error.class.name, "error.message" => error.message.to_s.truncate(ERROR_MESSAGE_LIMIT) }
+      end
+
+      def zero_tokens
+        { "input" => 0, "output" => 0, "thinking" => 0, "total" => 0 }
+      end
+
+      def token_totals(payload)
+        initial_count = Array(payload[:input_messages]).size
+        new_messages = Array(payload[:messages_after])[initial_count..] || []
+        assistant_messages = new_messages.select { |message| message.respond_to?(:role) && message.role.to_s == "assistant" }
+
+        tokens = {
+          "input" => sum_tokens(assistant_messages, :input_tokens),
+          "output" => sum_tokens(assistant_messages, :output_tokens),
+          "thinking" => sum_tokens(assistant_messages, :thinking_tokens)
+        }
+        tokens["total"] = tokens.values.sum
+        tokens
+      end
+
+      def sum_tokens(messages, method_name)
+        messages.sum { |message| message.respond_to?(method_name) ? message.public_send(method_name).to_i : 0 }
+      end
+
       def post_traces(body)
+        return deliver(body) unless @async
+
+        Thread.new { deliver(body) }
+      end
+
+      def deliver(body)
         uri = URI.parse(endpoint)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = uri.scheme == "https"
@@ -171,8 +277,47 @@ module ActiveAgents
         request["Content-Type"] = "application/json"
         request["Authorization"] = "Bearer #{api_key}"
         request.body = JSON.generate(body)
+        http.request(request)
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
+      end
+    end
 
-        Thread.new { http.request(request) }
+    # Evented ActiveSupport::Notifications subscriber; finish fires even when
+    # the instrumented block raises, with the exception on the payload.
+    class ChatSubscriber
+      def start(_name, _id, _payload)
+        state = RubyLLMTelemetry.state
+        state.started_at = Time.current if state.depth.zero?
+        state.depth += 1
+      end
+
+      def finish(_name, _id, payload)
+        state = RubyLLMTelemetry.state
+        state.rounds += 1
+        state.depth -= 1
+        return unless state.depth.zero?
+
+        begin
+          RubyLLMTelemetry.report_chat(payload, state.started_at, Time.current, tool_spans: state.tool_spans, rounds: state.rounds)
+        rescue StandardError => e
+          warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
+        ensure
+          RubyLLMTelemetry.clear_state
+        end
+      end
+    end
+
+    class ToolCallSubscriber
+      def start(_name, _id, payload)
+        payload[TOOL_STARTED_AT_KEY] = Time.current
+      end
+
+      def finish(_name, _id, payload)
+        started_at = payload.delete(TOOL_STARTED_AT_KEY) || Time.current
+        RubyLLMTelemetry.state.tool_spans << RubyLLMTelemetry.build_tool_span(payload, started_at, Time.current)
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
       end
     end
   end
@@ -181,16 +326,45 @@ end
 
 Notes:
 
-- **Tokens** come straight from RubyLLM's response message
-  (`input_tokens`/`output_tokens`); durations from the notification event.
-- **Tool calls**: `tool_call.ruby_llm` events fire outside the chat event;
-  a future version can correlate them into tool spans via the same
-  thread-local. For now tool rounds appear as separate completions.
-- **Failures** surface as `status: "ERROR"` traces with the exception
-  attached, matching what the gem's own instrumentation emits.
-- Requests are fire-and-forget on a background thread; batch buffering
-  (like `ActiveAgent::Telemetry::Reporter`) is a natural upgrade if volume
+- **Tokens** are summed from the assistant messages added during the ask
+  (`input_tokens`/`output_tokens`/`thinking_tokens` per message), which is
+  the accurate per-round accounting; the event-level token fields on nested
+  events double-report the final round.
+- **Tool spans** carry real start/end times, so the dashboard's waterfall,
+  generation-vs-tools breakdown, and slowest-operations views work for
+  RubyLLM apps the same as for platform-executed agents. Concurrent tool
+  execution (when enabled on the chat) runs tools off-thread and is not
+  captured — sequential execution (the default) is fully covered.
+- **Failures** surface as `status: "ERROR"` traces with the exception class
+  and a truncated message attached.
+- Requests are fire-and-forget on a background thread; pass `async: false`
+  for deterministic delivery in tests, and stub `post_traces` to assert on
+  the built payload. Batch buffering (like
+  `ActiveAgent::Telemetry::Reporter`) is a natural upgrade if volume
   warrants it.
+
+## Local / self-hosted dashboards
+
+The endpoint is just a parameter — point it at any deployment of this app or
+of the gem's dashboard:
+
+```ruby
+ActiveAgents::RubyLLMTelemetry.subscribe!(
+  api_key: ENV["ACTIVEAGENTS_API_KEY"],
+  endpoint: ENV.fetch("ACTIVEAGENTS_TELEMETRY_ENDPOINT", ActiveAgents::RubyLLMTelemetry::DEFAULT_ENDPOINT),
+  service_name: "my-app",
+  environment: Rails.env
+)
+```
+
+For a dashboard running locally (e.g. via `docker-compose.dev.yml` under
+OrbStack/Docker Desktop — see `docs/local-mac-llm.md`), set
+`ACTIVEAGENTS_TELEMETRY_ENDPOINT=http://localhost:3000/v1/traces` (or the
+container's `*.orb.local` hostname) in the reporting app. The Bearer token
+is either a platform API key generated from Settings → API Keys (`aa_…`
+keys, once PR
+[#96](https://github.com/activeagents/activeagents/pull/96) lands) or the
+account's legacy `telemetry_api_key` from the Organization page.
 
 ## Wire format reference
 
@@ -207,4 +381,5 @@ dashboard.
 The right long-term home for this adapter is the activeagent gem itself
 (e.g. `ActiveAgent::Telemetry::Adapters::RubyLLM`, loadable without the
 rest of the framework) so RubyLLM users get a supported, versioned client
-instead of a vendored file.
+instead of a vendored file. First production consumer: Sparkle's Clara
+admin chat (`combinaut/sparkle`, `lib/active_agents/ruby_llm_telemetry.rb`).

--- a/docs/integrations/ruby_llm.md
+++ b/docs/integrations/ruby_llm.md
@@ -63,22 +63,59 @@ end
 
 ### How events map to spans
 
-A chat that runs tools emits **nested** `chat.ruby_llm` events — each tool
-round recurses through `RubyLLM::Chat#complete`, and the outer event's token
-fields repeat the final round's counts. The adapter therefore builds **one
-trace per outermost event**:
+RubyLLM emits a `chat.ruby_llm` event per provider round, and the two
+generations of the gem arrange those rounds differently:
+
+- **1.x** recurses through `Chat#complete` for each tool round, so the rounds
+  **nest** inside the enclosing event and `tool_call.ruby_llm` fires within it.
+- **2.x** drives a flat `step until complete?` loop, so the rounds are
+  **siblings** and tool calls fire *between* them.
+
+The adapter accumulates rounds and flushes on the round that ends the turn —
+the one that errors, or answers without requesting tools (`payload[:tool_call]`)
+— which produces the same trace under both arrangements:
 
 - a `root` span named `Agent.action`,
-- a single `llm` span covering the whole provider loop (tools execute inside
-  it — the same shape the dashboard's generation-vs-tools time breakdown
-  expects), with token totals summed from the assistant messages the ask
-  added, so nested rounds are not double counted, and
-- a `tool` span per `tool_call.ruby_llm` event, with real start/end times
-  and `tool.name` / `tool.call_id` attributes, parented under the llm span.
+- one `llm` span covering the whole provider loop, carrying `llm.rounds` and
+  token totals summed **per round** from the assistant messages that round
+  added (the event-level token fields repeat the last round's counts, so they
+  are not used), and
+- a `tool` span per `tool_call.ruby_llm` event, with real start/end times and
+  `tool.name` / `tool.call_id`, parented under the llm span.
 
-Tool arguments and results are deliberately never sent, and error messages
-are truncated — safe defaults for apps whose tool traffic may contain
-sensitive data.
+Tool arguments and results are deliberately never sent, and error messages are
+truncated — safe defaults for apps whose tool traffic may contain sensitive
+data.
+
+### Attributing traffic
+
+RubyLLM carries no application identity on the payload: neither the
+`RubyLLM::Agent` class nor an `acts_as_chat` record reaches the instrumenter,
+so unattributed traffic reports as `RubyLLM::Chat`. Three ways to name it:
+
+```ruby
+# 1. Per call site.
+ActiveAgents::RubyLLMTelemetry.with_agent("SupportBot", action: "respond") { chat.ask(...) }
+
+# 2. From the initializer, derived from the event payload.
+ActiveAgents::RubyLLMTelemetry.subscribe!(
+  api_key: ENV["ACTIVEAGENTS_API_KEY"],
+  agent_resolver: ->(payload) { { name: "SupportBot", action: payload[:tools].present? ? "respond" : "summarize" } }
+)
+
+# 3. Every RubyLLM::Agent subclass, by class name.
+module AgentTelemetryAttribution
+  def ask(...)
+    ActiveAgents::RubyLLMTelemetry.with_agent(self.class.name) { super }
+  end
+end
+RubyLLM::Agent.prepend(AgentTelemetryAttribution)
+```
+
+Option 3 covers `SupportAgent.new.ask(...)` and Rails-backed
+`Agent.create!/find` instances. It does **not** cover `SupportAgent.chat`,
+which hands back a bare `RubyLLM::Chat` — wrap those call sites, or resolve
+from the payload.
 
 ### The adapter
 
@@ -89,27 +126,52 @@ require "json"
 require "securerandom"
 
 module ActiveAgents
-  # Reports RubyLLM chat completions to an ActiveAgents-compatible trace
-  # endpoint (POST /v1/traces — the wire format ActiveAgent::Telemetry uses).
+  # Reports RubyLLM chats to an ActiveAgents-compatible trace endpoint
+  # (POST /v1/traces — the wire format ActiveAgent::Telemetry uses).
   #
   # Requires RubyLLM.config.instrumenter = ActiveSupport::Notifications.
+  #
+  # One trace per conversation turn: a root span, an llm span covering the
+  # whole provider loop, and a tool span per tool_call.ruby_llm event.
+  #
+  # RubyLLM emits a chat.ruby_llm event per provider round, and the two
+  # generations of the gem arrange those rounds differently: through 1.x a
+  # tool round recurses inside the enclosing event, while 2.x drives a flat
+  # `step until complete?` loop whose rounds are siblings with tool calls
+  # firing between them. Rounds are therefore accumulated and flushed on the
+  # round that ends the turn — the one that errors or answers without
+  # requesting tools — which yields the same trace under both arrangements.
+  # Tokens are summed per round from the assistant messages that round added,
+  # so a repeated event-level count is never double counted.
+  #
+  # Tool arguments and results are never sent; error messages are truncated.
   module RubyLLMTelemetry
-    DEFAULT_ENDPOINT = "https://api.activeagents.ai/v1/traces"
+    DEFAULT_ENDPOINT = "https://api.activeagents.ai/v1/traces".freeze
     AGENT_KEY = :active_agents_ruby_llm_agent
     STATE_KEY = :active_agents_ruby_llm_state
     TOOL_STARTED_AT_KEY = :_active_agents_started_at
     ERROR_MESSAGE_LIMIT = 200
+    # A turn that never reaches a final round (a halted tool call, or an app
+    # driving RubyLLM 2.x's `step` by hand) would otherwise accumulate forever.
+    MAX_TURN_SECONDS = 600
 
-    State = Struct.new(:depth, :started_at, :tool_spans, :rounds)
+    State = Struct.new(:depth, :started_at, :tool_spans, :rounds, :tokens, :chat_key)
 
     class << self
       attr_reader :endpoint, :api_key, :service_name, :environment
 
-      def subscribe!(api_key:, endpoint: DEFAULT_ENDPOINT, service_name: nil, environment: nil, async: true)
+      # agent_resolver: optional callable receiving the chat event payload and
+      # returning { name:, action: }, so traffic can be attributed from an
+      # initializer alone; an enclosing with_agent block still wins. RubyLLM
+      # carries no application identity on the payload — neither RubyLLM::Agent
+      # nor an acts_as_chat record reaches the instrumenter — so unattributed
+      # traffic reports as RubyLLM::Chat.
+      def subscribe!(api_key:, endpoint: DEFAULT_ENDPOINT, service_name: nil, environment: nil, agent_resolver: nil, async: true)
         @api_key = api_key
         @endpoint = endpoint
         @service_name = service_name || default_service_name
         @environment = environment || default_environment
+        @agent_resolver = agent_resolver
         @async = async
 
         @subscriptions ||= [
@@ -123,8 +185,7 @@ module ActiveAgents
         @subscriptions = nil
       end
 
-      # Attributes traces inside the block to a named agent/action; otherwise
-      # traffic reports as RubyLLM::Chat. Safe to call when not subscribed.
+      # Attributes traces inside the block to a named agent/action.
       def with_agent(name, action: "chat")
         previous = Thread.current[AGENT_KEY]
         Thread.current[AGENT_KEY] = { name: name, action: action }
@@ -134,18 +195,74 @@ module ActiveAgents
       end
 
       def state
-        Thread.current[STATE_KEY] ||= State.new(0, nil, [], 0)
+        Thread.current[STATE_KEY] ||= State.new(0, nil, [], 0, zero_tokens, nil)
       end
 
       def clear_state
         Thread.current[STATE_KEY] = nil
       end
 
-      def report_chat(payload, started_at, finished_at, tool_spans:, rounds:)
-        agent = Thread.current[AGENT_KEY] || { name: "RubyLLM::Chat", action: "chat" }
+      # Reports whatever the current turn has accumulated. Apps that drive
+      # RubyLLM 2.x's `step`/`run_tools` themselves can call this to close a
+      # turn that ends while tool calls are still pending.
+      def flush!(payload = {})
+        turn = Thread.current[STATE_KEY]
+        return if turn.nil? || turn.rounds.zero?
+
+        clear_state
+        report_turn(payload, turn)
+      end
+
+      def begin_round(payload)
+        turn = state
+        if turn.depth.zero?
+          chat_key = payload[:chat].object_id
+          flush! if turn.rounds.positive? && (turn.chat_key != chat_key || turn_expired?(turn))
+          turn = state
+          turn.chat_key = chat_key
+          turn.started_at ||= Time.current
+        end
+        turn.depth += 1
+      end
+
+      def finish_round(payload)
+        turn = state
+        turn.depth -= 1
+        return unless turn.depth.zero?
+
+        turn.rounds += 1
+        accumulate_tokens(turn, payload)
+        flush!(payload) if payload[:exception_object] || !payload[:tool_call]
+      end
+
+      def build_tool_span(payload, started_at, finished_at)
+        error = payload[:exception_object]
+        attributes = { "tool.name" => payload[:tool_name].to_s, "tool.call_id" => payload[:tool_call_id].to_s }
+        attributes.merge!(error_attributes(error)) if error
+
+        {
+          "span_id" => SecureRandom.hex(8),
+          "name" => "tool.#{payload[:tool_name]}",
+          "type" => "tool",
+          "start_time" => started_at.utc.iso8601(6),
+          "end_time" => finished_at.utc.iso8601(6),
+          "duration_ms" => duration_ms(started_at, finished_at),
+          "status" => error ? "ERROR" : "OK",
+          "attributes" => attributes,
+          "tokens" => zero_tokens,
+          "events" => []
+        }
+      end
+
+      private
+
+      def report_turn(payload, turn)
+        agent = Thread.current[AGENT_KEY] || resolve_agent(payload) || { name: "RubyLLM::Chat", action: "chat" }
         trace_id = SecureRandom.hex(16)
         root_id = SecureRandom.hex(8)
         llm_id = SecureRandom.hex(8)
+        started_at = turn.started_at || Time.current
+        finished_at = Time.current
         error = payload[:exception_object]
 
         base = {
@@ -178,50 +295,45 @@ module ActiveAgents
           "attributes" => {
             "llm.provider" => payload[:provider].to_s,
             "llm.model" => payload[:model].to_s,
-            "llm.rounds" => rounds,
+            "llm.rounds" => turn.rounds,
             "llm.streaming" => payload[:streaming] || false
           },
-          "tokens" => token_totals(payload)
+          "tokens" => turn.tokens
         )
 
-        child_tool_spans = tool_spans.map { |tool_span| tool_span.merge("trace_id" => trace_id, "parent_span_id" => llm_id) }
+        tool_spans = turn.tool_spans.map { |span| span.merge("trace_id" => trace_id, "parent_span_id" => llm_id) }
 
         post_traces(
-          "traces" => [ {
+          "traces" => [{
             "trace_id" => trace_id,
             "service_name" => service_name,
             "environment" => environment,
             "timestamp" => finished_at.utc.iso8601(6),
             "resource_attributes" => {},
-            "spans" => [ root_span, llm_span ] + child_tool_spans
-          } ],
-          "sdk" => { "name" => "active_agents-ruby_llm", "version" => "1.1", "language" => "ruby", "runtime_version" => RUBY_VERSION }
+            "spans" => [root_span, llm_span] + tool_spans
+          }],
+          "sdk" => { "name" => "active_agents-ruby_llm", "version" => "1.2", "language" => "ruby", "runtime_version" => RUBY_VERSION }
         )
       end
 
-      def build_tool_span(payload, started_at, finished_at)
-        error = payload[:exception_object]
-        attributes = {
-          "tool.name" => payload[:tool_name].to_s,
-          "tool.call_id" => payload[:tool_call_id].to_s
-        }
-        attributes.merge!(error_attributes(error)) if error
-
-        {
-          "span_id" => SecureRandom.hex(8),
-          "name" => "tool.#{payload[:tool_name]}",
-          "type" => "tool",
-          "start_time" => started_at.utc.iso8601(6),
-          "end_time" => finished_at.utc.iso8601(6),
-          "duration_ms" => duration_ms(started_at, finished_at),
-          "status" => error ? "ERROR" : "OK",
-          "attributes" => attributes,
-          "tokens" => zero_tokens,
-          "events" => []
-        }
+      def turn_expired?(turn)
+        turn.started_at.nil? || (Time.current - turn.started_at) > MAX_TURN_SECONDS
       end
 
-      private
+      def accumulate_tokens(turn, payload)
+        round_tokens = token_totals(payload)
+        turn.tokens = turn.tokens.merge(round_tokens) { |_key, carried, added| carried + added }
+      end
+
+      def resolve_agent(payload)
+        agent = @agent_resolver&.call(payload)
+        return unless agent.is_a?(Hash) && agent[:name].present?
+
+        { name: agent[:name], action: agent[:action] || "chat" }
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] agent_resolver failed: #{e.class}: #{e.message}"
+        nil
+      end
 
       def default_service_name
         defined?(Rails) ? Rails.application.class.module_parent_name.underscore : "ruby_llm"
@@ -286,25 +398,17 @@ module ActiveAgents
     # Evented ActiveSupport::Notifications subscriber; finish fires even when
     # the instrumented block raises, with the exception on the payload.
     class ChatSubscriber
-      def start(_name, _id, _payload)
-        state = RubyLLMTelemetry.state
-        state.started_at = Time.current if state.depth.zero?
-        state.depth += 1
+      def start(_name, _id, payload)
+        RubyLLMTelemetry.begin_round(payload)
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
       end
 
       def finish(_name, _id, payload)
-        state = RubyLLMTelemetry.state
-        state.rounds += 1
-        state.depth -= 1
-        return unless state.depth.zero?
-
-        begin
-          RubyLLMTelemetry.report_chat(payload, state.started_at, Time.current, tool_spans: state.tool_spans, rounds: state.rounds)
-        rescue StandardError => e
-          warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
-        ensure
-          RubyLLMTelemetry.clear_state
-        end
+        RubyLLMTelemetry.finish_round(payload)
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
+        RubyLLMTelemetry.clear_state
       end
     end
 
@@ -326,17 +430,27 @@ end
 
 Notes:
 
-- **Tokens** are summed from the assistant messages added during the ask
-  (`input_tokens`/`output_tokens`/`thinking_tokens` per message), which is
-  the accurate per-round accounting; the event-level token fields on nested
-  events double-report the final round.
+- **Scope is chat and tool calls.** RubyLLM also emits `request.ruby_llm`,
+  `embedding.ruby_llm`, `image.ruby_llm`, `moderation.ruby_llm`,
+  `speech.ruby_llm`, `transcription.ruby_llm`, and
+  `models.refresh.ruby_llm`. An app whose RubyLLM usage is embeddings or
+  transcription reports nothing today; those events carry their own token
+  counts and are a natural extension of the same subscriber.
 - **Tool spans** carry real start/end times, so the dashboard's waterfall,
   generation-vs-tools breakdown, and slowest-operations views work for
   RubyLLM apps the same as for platform-executed agents. Concurrent tool
-  execution (when enabled on the chat) runs tools off-thread and is not
-  captured — sequential execution (the default) is fully covered.
+  execution runs tools off the instrumented thread and is not captured —
+  sequential execution (the default) is fully covered.
+- **Fallbacks** (`with_fallbacks`) retry a failed round against the next
+  model in a loop, so each failed attempt closes its own `ERROR` trace and
+  the successful attempt closes an `OK` one. That reads as one trace per
+  provider attempt, which is what the latency and error-rate metrics want.
+- **A turn that never reaches a final round** — a halted tool call, or an app
+  driving 2.x's `step`/`run_tools` by hand — is flushed when the next chat
+  reports, when `MAX_TURN_SECONDS` elapses, or on an explicit `flush!`.
 - **Failures** surface as `status: "ERROR"` traces with the exception class
-  and a truncated message attached.
+  and a truncated message attached. Delivery failures (ingest down, bad key)
+  are warned and swallowed, never raised into the app.
 - Requests are fire-and-forget on a background thread; pass `async: false`
   for deterministic delivery in tests, and stub `post_traces` to assert on
   the built payload. Batch buffering (like

--- a/ruby_llm_telemetry/README.md
+++ b/ruby_llm_telemetry/README.md
@@ -1,0 +1,91 @@
+# active_agents-ruby_llm_telemetry
+
+Reports [RubyLLM](https://github.com/crmne/ruby_llm) chats to an
+ActiveAgents-compatible trace endpoint (`POST /v1/traces`) — the hosted
+platform, or any self-hosted ActiveAgent dashboard.
+
+For apps built directly on RubyLLM: no ActiveAgent framework dependency,
+nothing beyond ActiveSupport and stdlib. Apps that can adopt
+`ActiveAgent::Base` should use the framework's `ruby_llm` provider instead,
+which reports telemetry on its own.
+
+## Install
+
+```ruby
+# Gemfile
+gem "active_agents-ruby_llm_telemetry",
+    github: "activeagents/activeagents", glob: "ruby_llm_telemetry/*.gemspec"
+```
+
+## Use
+
+```ruby
+# config/initializers/ruby_llm.rb
+RubyLLM.configure do |config|
+  config.instrumenter = ActiveSupport::Notifications # RubyLLM 1.x; 2.x wires this up in Rails
+end
+
+ActiveAgents::RubyLLMTelemetry.subscribe!(
+  api_key: ENV["ACTIVEAGENTS_API_KEY"],
+  endpoint: ENV.fetch("ACTIVEAGENTS_TELEMETRY_ENDPOINT", ActiveAgents::RubyLLMTelemetry::DEFAULT_ENDPOINT),
+  service_name: "my-app",
+  environment: Rails.env
+)
+```
+
+The key is a platform API key (Settings → API Keys) or an account's legacy
+`telemetry_api_key`. Delivery is fire-and-forget on a background thread, and
+failures are warned and swallowed — telemetry never raises into the app.
+
+## What a turn looks like
+
+One trace per conversation turn: a `root` span (`Agent.action`), one `llm`
+span covering the whole provider loop with `llm.rounds` and token totals, and
+a `tool` span per tool call with real timings.
+
+RubyLLM emits a `chat.ruby_llm` event per provider round, and the two
+generations arrange them differently — 1.x nests a tool round inside the
+enclosing event, 2.x drives a flat `step until complete?` loop whose rounds
+are siblings with tool calls between them. Rounds are accumulated and flushed
+on the round that ends the turn, so both produce the same trace.
+
+Tool arguments and results are never sent; error messages are truncated.
+
+## Naming the traffic
+
+RubyLLM carries no application identity on the payload — neither a
+`RubyLLM::Agent` class nor an `acts_as_chat` record reaches the instrumenter
+— so unattributed traffic reports as `RubyLLM::Chat`:
+
+```ruby
+# Per call site
+ActiveAgents::RubyLLMTelemetry.with_agent("SupportBot", action: "respond") { chat.ask(...) }
+
+# Or from the initializer, derived from the event payload
+subscribe!(api_key: ..., agent_resolver: ->(payload) { { name: "SupportBot", action: payload[:tools].present? ? "respond" : "summarize" } })
+
+# Or name every RubyLLM::Agent subclass by its class
+module AgentTelemetryAttribution
+  def ask(...) = ActiveAgents::RubyLLMTelemetry.with_agent(self.class.name) { super }
+end
+RubyLLM::Agent.prepend(AgentTelemetryAttribution)
+```
+
+## Scope
+
+Chat completions and tool calls. RubyLLM's `embedding`, `image`,
+`moderation`, `speech`, `transcription`, `request`, and `models.refresh`
+events are not reported yet — they carry their own token counts and are a
+natural extension of the same subscriber.
+
+Concurrent tool execution runs tools off the instrumented thread and is not
+captured; sequential execution (the default) is fully covered. A turn left
+open by a halted tool call, or by an app driving 2.x's `step`/`run_tools` by
+hand, is flushed when the next chat reports, after `MAX_TURN_SECONDS`, or on
+an explicit `flush!`.
+
+## Tests
+
+```bash
+cd ruby_llm_telemetry && bundle exec rake test
+```

--- a/ruby_llm_telemetry/Rakefile
+++ b/ruby_llm_telemetry/Rakefile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/test_*.rb"]
+  t.verbose    = true
+end
+
+task default: :test

--- a/ruby_llm_telemetry/active_agents-ruby_llm_telemetry.gemspec
+++ b/ruby_llm_telemetry/active_agents-ruby_llm_telemetry.gemspec
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "lib/active_agents/ruby_llm_telemetry/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "active_agents-ruby_llm_telemetry"
+  spec.version = ActiveAgents::RubyLLMTelemetry::VERSION
+  spec.authors = [ "ActiveAgents" ]
+  spec.email = [ "hello@activeagents.ai" ]
+
+  spec.summary = "Report RubyLLM chats to an ActiveAgents trace endpoint"
+  spec.description = <<~DESC
+    Subscribes to RubyLLM's instrumentation events and reports each chat turn
+    as a trace — a root span, an llm span, and a span per tool call — to the
+    ActiveAgents platform or any self-hosted ActiveAgent dashboard
+    (POST /v1/traces). Works with apps built directly on RubyLLM: no
+    ActiveAgent framework dependency, nothing beyond ActiveSupport and stdlib.
+  DESC
+
+  spec.homepage = "https://github.com/activeagents/activeagents"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.2.0"
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "#{spec.homepage}/tree/main/ruby_llm_telemetry"
+  }
+
+  spec.files = Dir["lib/**/*.rb", "README.md"]
+  spec.require_paths = [ "lib" ]
+
+  spec.add_dependency "activesupport", ">= 7.0"
+end

--- a/ruby_llm_telemetry/lib/active_agents/ruby_llm_telemetry.rb
+++ b/ruby_llm_telemetry/lib/active_agents/ruby_llm_telemetry.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+require "securerandom"
+require "active_support"
+require "active_support/core_ext/object/blank"
+require "active_support/core_ext/string/filters"
+require "active_support/core_ext/time"
+
+require_relative "ruby_llm_telemetry/version"
+
+module ActiveAgents
+  # Reports RubyLLM chats to an ActiveAgents-compatible trace endpoint
+  # (POST /v1/traces — the wire format ActiveAgent::Telemetry uses).
+  #
+  # Requires RubyLLM.config.instrumenter = ActiveSupport::Notifications.
+  #
+  # One trace per conversation turn: a root span, an llm span covering the
+  # whole provider loop, and a tool span per tool_call.ruby_llm event.
+  #
+  # RubyLLM emits a chat.ruby_llm event per provider round, and the two
+  # generations of the gem arrange those rounds differently: through 1.x a
+  # tool round recurses inside the enclosing event, while 2.x drives a flat
+  # `step until complete?` loop whose rounds are siblings with tool calls
+  # firing between them. Rounds are therefore accumulated and flushed on the
+  # round that ends the turn — the one that errors or answers without
+  # requesting tools — which yields the same trace under both arrangements.
+  # Tokens are summed per round from the assistant messages that round added,
+  # so a repeated event-level count is never double counted.
+  #
+  # Tool arguments and results are never sent; error messages are truncated.
+  module RubyLLMTelemetry
+    DEFAULT_ENDPOINT = 'https://api.activeagents.ai/v1/traces'.freeze
+    AGENT_KEY = :active_agents_ruby_llm_agent
+    STATE_KEY = :active_agents_ruby_llm_state
+    TOOL_STARTED_AT_KEY = :_active_agents_started_at
+    ERROR_MESSAGE_LIMIT = 200
+    # A turn that never reaches a final round (a halted tool call, or an app
+    # driving RubyLLM 2.x's `step` by hand) would otherwise accumulate forever.
+    MAX_TURN_SECONDS = 600
+
+    State = Struct.new(:depth, :started_at, :tool_spans, :rounds, :tokens, :chat_key)
+
+    class << self
+      attr_reader :endpoint, :api_key, :service_name, :environment
+
+      # agent_resolver: optional callable receiving the chat event payload and
+      # returning { name:, action: }, so traffic can be attributed from an
+      # initializer alone; an enclosing with_agent block still wins. RubyLLM
+      # carries no application identity on the payload — neither RubyLLM::Agent
+      # nor an acts_as_chat record reaches the instrumenter — so unattributed
+      # traffic reports as RubyLLM::Chat.
+      def subscribe!(api_key:, endpoint: DEFAULT_ENDPOINT, service_name: nil, environment: nil, agent_resolver: nil, async: true)
+        @api_key = api_key
+        @endpoint = endpoint
+        @service_name = service_name || default_service_name
+        @environment = environment || default_environment
+        @agent_resolver = agent_resolver
+        @async = async
+
+        @subscriptions ||= [
+          ActiveSupport::Notifications.subscribe('chat.ruby_llm', ChatSubscriber.new),
+          ActiveSupport::Notifications.subscribe('tool_call.ruby_llm', ToolCallSubscriber.new)
+        ]
+      end
+
+      def unsubscribe!
+        Array(@subscriptions).each { |subscription| ActiveSupport::Notifications.unsubscribe(subscription) }
+        @subscriptions = nil
+      end
+
+      # Attributes traces inside the block to a named agent/action.
+      def with_agent(name, action: 'chat')
+        previous = Thread.current[AGENT_KEY]
+        Thread.current[AGENT_KEY] = { name: name, action: action }
+        yield
+      ensure
+        Thread.current[AGENT_KEY] = previous
+      end
+
+      def state
+        Thread.current[STATE_KEY] ||= State.new(0, nil, [], 0, zero_tokens, nil)
+      end
+
+      def clear_state
+        Thread.current[STATE_KEY] = nil
+      end
+
+      # Reports whatever the current turn has accumulated. Apps that drive
+      # RubyLLM 2.x's `step`/`run_tools` themselves can call this to close a
+      # turn that ends while tool calls are still pending.
+      def flush!(payload = {})
+        turn = Thread.current[STATE_KEY]
+        return if turn.nil? || turn.rounds.zero?
+
+        clear_state
+        report_turn(payload, turn)
+      end
+
+      def begin_round(payload)
+        turn = state
+        if turn.depth.zero?
+          chat_key = payload[:chat].object_id
+          flush! if turn.rounds.positive? && (turn.chat_key != chat_key || turn_expired?(turn))
+          turn = state
+          turn.chat_key = chat_key
+          turn.started_at ||= Time.current
+        end
+        turn.depth += 1
+      end
+
+      def finish_round(payload)
+        turn = state
+        turn.depth -= 1
+        return unless turn.depth.zero?
+
+        turn.rounds += 1
+        accumulate_tokens(turn, payload)
+        flush!(payload) if payload[:exception_object] || !payload[:tool_call]
+      end
+
+      def build_tool_span(payload, started_at, finished_at)
+        error = payload[:exception_object]
+        attributes = { 'tool.name' => payload[:tool_name].to_s, 'tool.call_id' => payload[:tool_call_id].to_s }
+        attributes.merge!(error_attributes(error)) if error
+
+        {
+          'span_id' => SecureRandom.hex(8),
+          'name' => "tool.#{payload[:tool_name]}",
+          'type' => 'tool',
+          'start_time' => started_at.utc.iso8601(6),
+          'end_time' => finished_at.utc.iso8601(6),
+          'duration_ms' => duration_ms(started_at, finished_at),
+          'status' => error ? 'ERROR' : 'OK',
+          'attributes' => attributes,
+          'tokens' => zero_tokens,
+          'events' => []
+        }
+      end
+
+      private
+
+      def report_turn(payload, turn)
+        agent = Thread.current[AGENT_KEY] || resolve_agent(payload) || { name: 'RubyLLM::Chat', action: 'chat' }
+        trace_id = SecureRandom.hex(16)
+        root_id = SecureRandom.hex(8)
+        llm_id = SecureRandom.hex(8)
+        started_at = turn.started_at || Time.current
+        finished_at = Time.current
+        error = payload[:exception_object]
+
+        base = {
+          'trace_id' => trace_id,
+          'start_time' => started_at.utc.iso8601(6),
+          'end_time' => finished_at.utc.iso8601(6),
+          'duration_ms' => duration_ms(started_at, finished_at),
+          'status' => error ? 'ERROR' : 'OK',
+          'events' => []
+        }
+
+        root_attributes = {
+          'agent.class' => agent[:name],
+          'agent.action' => agent[:action],
+          'agent.provider' => payload[:provider].to_s,
+          'agent.model' => payload[:model].to_s
+        }
+        root_attributes.merge!(error_attributes(error)) if error
+
+        root_span = base.merge(
+          'span_id' => root_id, 'parent_span_id' => nil,
+          'name' => "#{agent[:name]}.#{agent[:action]}", 'type' => 'root',
+          'attributes' => root_attributes,
+          'tokens' => zero_tokens
+        )
+
+        llm_span = base.merge(
+          'span_id' => llm_id, 'parent_span_id' => root_id,
+          'name' => 'llm.generate', 'type' => 'llm',
+          'attributes' => {
+            'llm.provider' => payload[:provider].to_s,
+            'llm.model' => payload[:model].to_s,
+            'llm.rounds' => turn.rounds,
+            'llm.streaming' => payload[:streaming] || false
+          },
+          'tokens' => turn.tokens
+        )
+
+        tool_spans = turn.tool_spans.map { |span| span.merge('trace_id' => trace_id, 'parent_span_id' => llm_id) }
+
+        post_traces(
+          'traces' => [{
+            'trace_id' => trace_id,
+            'service_name' => service_name,
+            'environment' => environment,
+            'timestamp' => finished_at.utc.iso8601(6),
+            'resource_attributes' => {},
+            'spans' => [root_span, llm_span] + tool_spans
+          }],
+          'sdk' => { 'name' => 'active_agents-ruby_llm_telemetry', 'version' => VERSION, 'language' => 'ruby', 'runtime_version' => RUBY_VERSION }
+        )
+      end
+
+      def turn_expired?(turn)
+        turn.started_at.nil? || (Time.current - turn.started_at) > MAX_TURN_SECONDS
+      end
+
+      def accumulate_tokens(turn, payload)
+        round_tokens = token_totals(payload)
+        turn.tokens = turn.tokens.merge(round_tokens) { |_key, carried, added| carried + added }
+      end
+
+      def resolve_agent(payload)
+        agent = @agent_resolver&.call(payload)
+        return unless agent.is_a?(Hash) && agent[:name].present?
+
+        { name: agent[:name], action: agent[:action] || 'chat' }
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] agent_resolver failed: #{e.class}: #{e.message}"
+        nil
+      end
+
+      def default_service_name
+        defined?(Rails) ? Rails.application.class.module_parent_name.underscore : 'ruby_llm'
+      end
+
+      def default_environment
+        defined?(Rails) ? Rails.env : ENV.fetch('RACK_ENV', 'production')
+      end
+
+      def duration_ms(started_at, finished_at)
+        ((finished_at - started_at) * 1000).round(2)
+      end
+
+      def error_attributes(error)
+        { 'error.type' => error.class.name, 'error.message' => error.message.to_s.truncate(ERROR_MESSAGE_LIMIT) }
+      end
+
+      def zero_tokens
+        { 'input' => 0, 'output' => 0, 'thinking' => 0, 'total' => 0 }
+      end
+
+      def token_totals(payload)
+        initial_count = Array(payload[:input_messages]).size
+        new_messages = Array(payload[:messages_after])[initial_count..] || []
+        assistant_messages = new_messages.select { |message| message.respond_to?(:role) && message.role.to_s == 'assistant' }
+
+        tokens = {
+          'input' => sum_tokens(assistant_messages, :input_tokens),
+          'output' => sum_tokens(assistant_messages, :output_tokens),
+          'thinking' => sum_tokens(assistant_messages, :thinking_tokens)
+        }
+        tokens['total'] = tokens.values.sum
+        tokens
+      end
+
+      def sum_tokens(messages, method_name)
+        messages.sum { |message| message.respond_to?(method_name) ? message.public_send(method_name).to_i : 0 }
+      end
+
+      def post_traces(body)
+        return deliver(body) unless @async
+
+        Thread.new { deliver(body) }
+      end
+
+      def deliver(body)
+        uri = URI.parse(endpoint)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == 'https'
+        http.open_timeout = http.read_timeout = 10
+
+        request = Net::HTTP::Post.new(uri.request_uri)
+        request['Content-Type'] = 'application/json'
+        request['Authorization'] = "Bearer #{api_key}"
+        request.body = JSON.generate(body)
+        http.request(request)
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
+      end
+    end
+
+    # Evented ActiveSupport::Notifications subscriber; finish fires even when
+    # the instrumented block raises, with the exception on the payload.
+    class ChatSubscriber
+      def start(_name, _id, payload)
+        RubyLLMTelemetry.begin_round(payload)
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
+      end
+
+      def finish(_name, _id, payload)
+        RubyLLMTelemetry.finish_round(payload)
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
+        RubyLLMTelemetry.clear_state
+      end
+    end
+
+    class ToolCallSubscriber
+      def start(_name, _id, payload)
+        payload[TOOL_STARTED_AT_KEY] = Time.current
+      end
+
+      def finish(_name, _id, payload)
+        started_at = payload.delete(TOOL_STARTED_AT_KEY) || Time.current
+        RubyLLMTelemetry.state.tool_spans << RubyLLMTelemetry.build_tool_span(payload, started_at, Time.current)
+      rescue StandardError => e
+        warn "[ActiveAgents::RubyLLMTelemetry] #{e.class}: #{e.message}"
+      end
+    end
+  end
+end

--- a/ruby_llm_telemetry/lib/active_agents/ruby_llm_telemetry.rb
+++ b/ruby_llm_telemetry/lib/active_agents/ruby_llm_telemetry.rb
@@ -189,14 +189,14 @@ module ActiveAgents
         tool_spans = turn.tool_spans.map { |span| span.merge('trace_id' => trace_id, 'parent_span_id' => llm_id) }
 
         post_traces(
-          'traces' => [{
+          'traces' => [ {
             'trace_id' => trace_id,
             'service_name' => service_name,
             'environment' => environment,
             'timestamp' => finished_at.utc.iso8601(6),
             'resource_attributes' => {},
-            'spans' => [root_span, llm_span] + tool_spans
-          }],
+            'spans' => [ root_span, llm_span ] + tool_spans
+          } ],
           'sdk' => { 'name' => 'active_agents-ruby_llm_telemetry', 'version' => VERSION, 'language' => 'ruby', 'runtime_version' => RUBY_VERSION }
         )
       end

--- a/ruby_llm_telemetry/lib/active_agents/ruby_llm_telemetry/version.rb
+++ b/ruby_llm_telemetry/lib/active_agents/ruby_llm_telemetry/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActiveAgents
+  module RubyLLMTelemetry
+    VERSION = "0.1.0"
+  end
+end

--- a/ruby_llm_telemetry/test/test_helper.rb
+++ b/ruby_llm_telemetry/test/test_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "active_agents/ruby_llm_telemetry"
+
+module TelemetryTestHelpers
+  Msg = Struct.new(:role, :input_tokens, :output_tokens, :thinking_tokens)
+
+  def setup
+    @posted = []
+    subscribe
+  end
+
+  def teardown
+    ActiveAgents::RubyLLMTelemetry.unsubscribe!
+    ActiveAgents::RubyLLMTelemetry.clear_state
+    Thread.current[ActiveAgents::RubyLLMTelemetry::AGENT_KEY] = nil
+  end
+
+  attr_reader :posted
+
+  # Captures the built payload instead of delivering it.
+  def subscribe(**options)
+    ActiveAgents::RubyLLMTelemetry.unsubscribe!
+    ActiveAgents::RubyLLMTelemetry.subscribe!(
+      api_key: "test-key", service_name: "test-app", environment: "test", async: false, **options
+    )
+    captured = @posted
+    ActiveAgents::RubyLLMTelemetry.singleton_class.define_method(:post_traces) { |body| captured << body }
+  end
+
+  def instrument(name, payload, &block)
+    ActiveSupport::Notifications.instrument(name, payload, &block)
+  end
+
+  def assistant(input:, output:, thinking: 0)
+    Msg.new("assistant", input, output, thinking)
+  end
+
+  def chat_payload(input_messages: [ Msg.new("user") ], chat: default_chat, **extra)
+    { chat: chat, provider: :openai, model: "gpt-4o", input_messages: input_messages, streaming: false }.merge(extra)
+  end
+
+  def default_chat
+    @default_chat ||= Object.new
+  end
+
+  def traces
+    posted.map { |body| body.fetch("traces").first }
+  end
+
+  def spans_of(trace, type)
+    trace.fetch("spans").select { |span| span["type"] == type }
+  end
+end

--- a/ruby_llm_telemetry/test/test_ruby_llm_telemetry.rb
+++ b/ruby_llm_telemetry/test/test_ruby_llm_telemetry.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestRubyLLMTelemetry < Minitest::Test
+  include TelemetryTestHelpers
+
+  def test_reports_a_completion_as_one_trace
+    payload = chat_payload
+    instrument("chat.ruby_llm", payload) do
+      payload[:messages_after] = payload[:input_messages] + [ assistant(input: 10, output: 5) ]
+    end
+
+    trace = traces.first
+    assert_equal 1, posted.size
+    assert_equal "test-app", trace["service_name"]
+    assert_equal %w[root llm], trace["spans"].map { |span| span["type"] }
+    assert_equal({ "input" => 10, "output" => 5, "thinking" => 0, "total" => 15 }, spans_of(trace, "llm").first["tokens"])
+  end
+
+  def test_reports_unattributed_traffic_as_ruby_llm_chat
+    instrument("chat.ruby_llm", chat_payload) { nil }
+
+    assert_equal "RubyLLM::Chat.chat", traces.first.fetch("spans").first["name"]
+  end
+
+  # RubyLLM 1.x recurses through Chat#complete, so tool rounds nest inside the
+  # enclosing chat event.
+  def test_nested_tool_rounds_build_one_trace
+    round_one = assistant(input: 10, output: 5)
+    tool_result = Msg.new("tool")
+    final = assistant(input: 20, output: 7)
+    outer = chat_payload(tool_call: false)
+
+    instrument("chat.ruby_llm", outer) do
+      instrument("tool_call.ruby_llm", { tool_name: "search_docs", tool_call_id: "call-1", tool_arguments: { "q" => "secret" } }) { nil }
+
+      inner = chat_payload(input_messages: outer[:input_messages] + [ round_one, tool_result ], tool_call: false)
+      instrument("chat.ruby_llm", inner) { inner[:messages_after] = inner[:input_messages] + [ final ] }
+
+      outer[:messages_after] = outer[:input_messages] + [ round_one, tool_result, final ]
+    end
+
+    trace = traces.first
+    llm_span = spans_of(trace, "llm").first
+    tool_span = spans_of(trace, "tool").first
+
+    assert_equal 1, posted.size, "nested round should not post its own trace"
+    assert_equal({ "input" => 30, "output" => 12, "thinking" => 0, "total" => 42 }, llm_span["tokens"])
+    assert_equal "search_docs", tool_span["attributes"]["tool.name"]
+    assert_equal llm_span["span_id"], tool_span["parent_span_id"]
+    refute_includes posted.first.to_json, "secret", "tool arguments must not be sent"
+  end
+
+  # RubyLLM 2.x drives a flat `step until complete?` loop, so rounds are
+  # siblings and tool calls fire between them.
+  def test_sibling_tool_rounds_build_one_trace
+    round_one = assistant(input: 10, output: 5)
+    tool_result = Msg.new("tool")
+    final = assistant(input: 20, output: 7)
+
+    first_round = chat_payload(tool_call: true)
+    instrument("chat.ruby_llm", first_round) { first_round[:messages_after] = first_round[:input_messages] + [ round_one ] }
+
+    instrument("tool_call.ruby_llm", { tool_name: "search_docs", tool_call_id: "call-1" }) { nil }
+
+    last_round = chat_payload(input_messages: first_round[:input_messages] + [ round_one, tool_result ], tool_call: false)
+    instrument("chat.ruby_llm", last_round) { last_round[:messages_after] = last_round[:input_messages] + [ final ] }
+
+    trace = traces.first
+    llm_span = spans_of(trace, "llm").first
+
+    assert_equal 1, posted.size, "intermediate round should accumulate, not post"
+    assert_equal 2, llm_span["attributes"]["llm.rounds"]
+    assert_equal({ "input" => 30, "output" => 12, "thinking" => 0, "total" => 42 }, llm_span["tokens"])
+    assert_equal 1, spans_of(trace, "tool").size, "between-rounds tool call should join the turn"
+  end
+
+  def test_a_different_chat_flushes_a_turn_left_open
+    instrument("chat.ruby_llm", chat_payload(tool_call: true)) { nil }
+    instrument("chat.ruby_llm", chat_payload(chat: Object.new, tool_call: false)) { nil }
+
+    assert_equal 2, posted.size
+  end
+
+  def test_a_raising_round_reports_an_error_trace
+    assert_raises(ArgumentError) do
+      instrument("chat.ruby_llm", chat_payload(tool_call: true)) { raise ArgumentError, "provider exploded" }
+    end
+
+    root_span = traces.first.fetch("spans").first
+    assert_equal "ERROR", root_span["status"]
+    assert_equal "ArgumentError", root_span["attributes"]["error.type"]
+  end
+
+  def test_flush_closes_a_turn_with_pending_tool_calls
+    payload = chat_payload(tool_call: true)
+    instrument("chat.ruby_llm", payload) { payload[:messages_after] = payload[:input_messages] + [ assistant(input: 10, output: 5) ] }
+    assert_empty posted, "a round with pending tool calls stays open"
+
+    ActiveAgents::RubyLLMTelemetry.flush!(payload)
+
+    assert_equal 1, posted.size
+  end
+
+  def test_agent_resolver_attributes_traffic_from_the_payload
+    subscribe(agent_resolver: ->(payload) { { name: "SupportBot", action: payload[:tools].any? ? "respond" : "summarize" } })
+
+    instrument("chat.ruby_llm", chat_payload(tools: %i[search_docs])) { nil }
+    instrument("chat.ruby_llm", chat_payload(chat: Object.new, tools: [])) { nil }
+
+    assert_equal %w[SupportBot.respond SupportBot.summarize], traces.map { |trace| trace.fetch("spans").first["name"] }
+  end
+
+  def test_with_agent_names_the_trace_and_restores_the_previous_attribution
+    ActiveAgents::RubyLLMTelemetry.with_agent("SupportBot", action: "respond") do
+      instrument("chat.ruby_llm", chat_payload) { nil }
+    end
+
+    assert_equal "SupportBot.respond", traces.first.fetch("spans").first["name"]
+    assert_nil Thread.current[ActiveAgents::RubyLLMTelemetry::AGENT_KEY]
+  end
+end


### PR DESCRIPTION
Converts the inline RubyLLM telemetry adapter from a vendored code snippet into a self-contained, published gem (`active_agents-ruby_llm_telemetry`). This enables versioned releases, easier maintenance, and potential future extraction into a separate repository.

## Key Changes

- **New gem structure**: Created `ruby_llm_telemetry/` directory with standard gem layout (lib, test, gemspec, Rakefile)
- **Enhanced event handling**: Replaced simple single-event reporting with stateful round accumulation that handles both RubyLLM 1.x (nested tool rounds) and 2.x (flat sibling rounds) architectures
- **Tool call spans**: Added `ToolCallSubscriber` to capture tool execution as separate spans with real start/end times, parented under the llm span
- **Improved attribution**: Added `agent_resolver` callback for deriving agent identity from event payload, complementing the existing `with_agent` block API
- **Async control**: Added `async` parameter to `subscribe!` for deterministic testing (defaults to true for production)
- **Turn lifecycle management**: Implemented turn flushing on chat object change, timeout (`MAX_TURN_SECONDS`), or explicit `flush!` call to handle incomplete turns
- **Token accumulation**: Changed from single-round token counts to per-round summation from assistant messages, preventing double-counting across multiple rounds
- **Comprehensive test suite**: Added 8 tests covering nested rounds, sibling rounds, error handling, agent resolution, and turn flushing

## Implementation Details

- State is thread-local, keyed by `STATE_KEY`, tracking depth, started_at, tool_spans, rounds, and tokens
- Rounds are accumulated until one errors or completes without tool calls, then the entire turn is reported as a single trace
- Tool spans are built with real timings and include `tool.name` and `tool.call_id` attributes; arguments and results are never sent
- Error messages are truncated to 200 characters for safety
- Delivery failures are warned and swallowed, never raised into the app
- Documentation updated with examples of all three attribution patterns and notes on scope, fallbacks, and self-hosted deployment

The gem has no dependencies beyond ActiveSupport (≥7.0) and Ruby stdlib, making it suitable for apps built directly on RubyLLM without the ActiveAgent framework.

https://claude.ai/code/session_01WxrbJbWwpMDH961afYqCpE