### PR TITLE
Give sandbox_sessions the columns the engine's MCP launch needs (into #102)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,10 @@ gem "rouge"
 # Inertia adapter for Rails [https://inertia-rails.dev]
 gem "inertia_rails"
 # Active Agent - AI agent framework for Rails [https://github.com/activeagents/activeagent]
-gem "activeagent", github: "activeagents/activeagent", branch: "claude/activeagents-local-engine-ky54n7"
+gem "activeagent", github: "activeagents/activeagent", branch: "claude/dashboard-tools-mcp-views-pdieob"
 # Action Agent - the dashboard, a mountable Rails engine. Lives in the same
 # repo as a sibling gem, hence the glob.
-gem "actionagent", github: "activeagents/activeagent", branch: "claude/activeagents-local-engine-ky54n7", glob: "actionagent/*.gemspec"
+gem "actionagent", github: "activeagents/activeagent", branch: "claude/dashboard-tools-mcp-views-pdieob", glob: "actionagent/*.gemspec"
 # Solid Agent - Persistence and context management for ActiveAgent
 gem "solid_agent", github: "activeagents/solid_agent", branch: "main"
 # RubyLLM - model registry (token pricing data) and unified provider API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/activeagents/activeagent.git
-  revision: 9eb389f8a3c0b36214306d493c8ac2b54f46d3aa
-  branch: claude/activeagents-local-engine-ky54n7
+  revision: c9a6ff3e8af085f340649b87f71560935b9cabfa
+  branch: claude/dashboard-tools-mcp-views-pdieob
   specs:
     activeagent (1.1.0)
       actionpack (>= 7.2, <= 9.0)
@@ -14,8 +14,8 @@ GIT
 
 GIT
   remote: https://github.com/activeagents/activeagent.git
-  revision: 9eb389f8a3c0b36214306d493c8ac2b54f46d3aa
-  branch: claude/activeagents-local-engine-ky54n7
+  revision: c9a6ff3e8af085f340649b87f71560935b9cabfa
+  branch: claude/dashboard-tools-mcp-views-pdieob
   glob: actionagent/*.gemspec
   specs:
     actionagent (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/activeagents/activeagent.git
-  revision: c9a6ff3e8af085f340649b87f71560935b9cabfa
+  revision: f224c15a99bec4949ef78f17f12e7792286e8be6
   branch: claude/dashboard-tools-mcp-views-pdieob
   specs:
     activeagent (1.1.0)
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/activeagents/activeagent.git
-  revision: c9a6ff3e8af085f340649b87f71560935b9cabfa
+  revision: f224c15a99bec4949ef78f17f12e7792286e8be6
   branch: claude/dashboard-tools-mcp-views-pdieob
   glob: actionagent/*.gemspec
   specs:

--- a/db/migrate/20260813000001_add_mcp_servers_to_sandbox_sessions.rb
+++ b/db/migrate/20260813000001_add_mcp_servers_to_sandbox_sessions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# The dashboard's MCP Services view can start a catalog server inside a
+# sandbox, and records which ones a session was launched with so a running
+# server reads as running instead of offering to start a second copy.
+#
+# The engine's install generator creates this column with the table; our
+# sandbox_sessions predates the engine, so it gets added here. Additive and
+# defaulted, so sessions created before this migration read as "no MCP
+# servers" rather than nil.
+class AddMcpServersToSandboxSessions < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:sandbox_sessions, :mcp_servers)
+      add_column :sandbox_sessions, :mcp_servers, :jsonb, default: []
+      # Containment (@>) is how the engine looks a server up across sessions.
+      add_index :sandbox_sessions, :mcp_servers, using: :gin
+    end
+
+    # SandboxSession declares `owned_by :user, :account`, and the engine's
+    # own schema carries both columns so a deployment's ownership shape
+    # stays a configuration change. Ours had only user_id, which is the one
+    # that scopes sandboxes here — add the other so the model can answer the
+    # same question every other dashboard model does.
+    unless column_exists?(:sandbox_sessions, :account_id)
+      add_column :sandbox_sessions, :account_id, :bigint
+      add_index :sandbox_sessions, :account_id
+    end
+  end
+
+  def down
+    remove_column :sandbox_sessions, :mcp_servers, if_exists: true
+    remove_column :sandbox_sessions, :account_id, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_08_12_200000) do
+ActiveRecord::Schema[8.2].define(version: 2026_08_13_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -620,6 +620,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_12_200000) do
   end
 
   create_table "sandbox_sessions", force: :cascade do |t|
+    t.bigint "account_id"
     t.bigint "agent_template_id"
     t.string "cloud_run_job_id"
     t.string "cloud_run_url"
@@ -628,6 +629,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_12_200000) do
     t.datetime "expires_at"
     t.datetime "last_activity_at"
     t.integer "max_runs", default: 10
+    t.jsonb "mcp_servers", default: []
     t.jsonb "runs", default: []
     t.integer "runs_count", default: 0
     t.string "sandbox_type", default: "playwright_mcp"
@@ -638,9 +640,11 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_12_200000) do
     t.integer "total_tokens", default: 0
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index ["account_id"], name: "index_sandbox_sessions_on_account_id"
     t.index ["agent_template_id"], name: "index_sandbox_sessions_on_agent_template_id"
     t.index ["cloud_run_job_id"], name: "index_sandbox_sessions_on_cloud_run_job_id"
     t.index ["expires_at"], name: "index_sandbox_sessions_on_expires_at"
+    t.index ["mcp_servers"], name: "index_sandbox_sessions_on_mcp_servers", using: :gin
     t.index ["sandbox_type"], name: "index_sandbox_sessions_on_sandbox_type"
     t.index ["session_id"], name: "index_sandbox_sessions_on_session_id", unique: true
     t.index ["status"], name: "index_sandbox_sessions_on_status"

--- a/script/seed_tool_inventory.rb
+++ b/script/seed_tool_inventory.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+# Seeds a realistic tool/MCP inventory for the demo account so the mounted
+# dashboard's Tools and MCP Services views have something to render in
+# development.
+#
+#   bin/rails runner script/seed_tool_inventory.rb
+#
+# Writes the same records a real run produces — telemetry traces with an
+# offered tool roster and executed tool spans, plus solid_agent contexts,
+# generations and tool messages — so the views exercise every detection
+# path rather than reading from a fixture the app doesn't otherwise use.
+
+user = User.find_by(email_address: "demo@example.com") || User.first
+abort "No user to seed against" unless user
+
+account = user.primary_account
+abort "No account for #{user.email_address}" unless account
+
+agent = user.agents.first
+puts "Seeding tool inventory for #{account.name} (#{user.email_address})"
+
+DECLARED = [
+  { "name" => "mcp__playwright__browser_navigate", "description" => "Open a URL in the managed browser.", "parameters" => [ "url" ] },
+  { "name" => "mcp__playwright__browser_snapshot", "description" => "Accessibility snapshot of the current page.", "parameters" => [] },
+  { "name" => "mcp__playwright__browser_click", "description" => "Click an element from the latest snapshot.", "parameters" => [ "ref", "element" ] },
+  { "name" => "mcp__github__create_issue", "description" => "File an issue on a GitHub repository.", "parameters" => [ "owner", "repo", "title", "body" ] },
+  { "name" => "mcp__github__search_code", "description" => "Search code across repositories.", "parameters" => [ "query" ] },
+  { "name" => "mcp__filesystem__read_text_file", "description" => "Read a UTF-8 file from an allowed directory.", "parameters" => [ "path" ] },
+  { "name" => "web_search", "description" => "Search the web and return a short summary.", "parameters" => [ "query" ] },
+  { "name" => "lookup_order", "description" => "Look up an order by its reference.", "parameters" => [ "order_id" ] },
+  { "name" => "escalate_to_human", "description" => "Hand the conversation to a human agent.", "parameters" => [ "reason" ] }
+].freeze
+
+# name => [call count, error count, avg duration]
+TRAFFIC = {
+  "mcp__playwright__browser_navigate" => [ 24, 1, 380.0 ],
+  "mcp__playwright__browser_snapshot" => [ 19, 0, 145.0 ],
+  "mcp__playwright__browser_click" => [ 12, 2, 210.0 ],
+  "mcp__github__create_issue" => [ 6, 0, 640.0 ],
+  "mcp__github__search_code" => [ 9, 1, 520.0 ],
+  "mcp__filesystem__read_text_file" => [ 31, 0, 22.0 ],
+  "web_search" => [ 14, 0, 810.0 ],
+  "lookup_order" => [ 7, 3, 95.0 ]
+  # escalate_to_human is deliberately absent: offered every run, never called.
+}.freeze
+
+def build_trace(account:, agent_class:, calls:, timestamp:, declared: nil)
+  spans = [
+    {
+      "span_id" => "r1", "parent_span_id" => nil, "name" => "#{agent_class}.respond",
+      "type" => "root", "duration_ms" => 1400.0, "status" => "OK",
+      "attributes" => { "agent.class" => agent_class, "agent.action" => "respond" },
+      "tokens" => { "input" => 820, "output" => 240, "thinking" => 0 }
+    }
+  ]
+
+  if declared
+    spans << {
+      "span_id" => "p1", "parent_span_id" => "r1", "name" => "prompt",
+      "type" => "prompt", "duration_ms" => 4.0, "status" => "OK",
+      "attributes" => { "prompt.input.tools" => declared.to_json }
+    }
+  end
+
+  spans << {
+    "span_id" => "l1", "parent_span_id" => "r1", "name" => "chat",
+    "type" => "llm", "duration_ms" => 1200.0, "status" => "OK",
+    "attributes" => { "llm.provider" => "anthropic", "llm.model" => "claude-sonnet-5" },
+    "tokens" => { "input" => 820, "output" => 240, "thinking" => 0 }
+  }
+
+  calls.each_with_index do |call, index|
+    attributes = { "tool.name" => call[:name] }
+    attributes["tool.input.args"] = call[:args] if call[:args]
+    attributes["error.message"] = call[:error] if call[:error]
+    spans << {
+      "span_id" => "t#{index}", "parent_span_id" => "l1", "name" => "tool.#{call[:name]}",
+      "type" => "tool", "duration_ms" => call[:duration], "status" => call[:error] ? "ERROR" : "OK",
+      "attributes" => attributes
+    }
+  end
+
+  TelemetryTrace.create_from_payload(
+    {
+      "trace_id" => SecureRandom.hex(16),
+      "service_name" => "support-app",
+      "environment" => "production",
+      "timestamp" => timestamp.iso8601(6),
+      "spans" => spans
+    },
+    { "name" => "activeagent", "version" => "1.1.0" },
+    account: account
+  )
+end
+
+SAMPLE_ARGS = {
+  "mcp__playwright__browser_navigate" => '{"url":"https://docs.activeagents.ai/tools"}',
+  "mcp__github__create_issue" => '{"owner":"activeagents","repo":"activeagent","title":"Tool timeout"}',
+  "mcp__filesystem__read_text_file" => '{"path":"/workspace/README.md"}',
+  "web_search" => '{"query":"model context protocol servers"}',
+  "lookup_order" => '{"order_id":"ORD-4417"}'
+}.freeze
+
+# Spread the traffic over the last few days so the window selectors differ.
+pending = TRAFFIC.transform_values { |(count, errors, duration)| { remaining: count, errors: errors, duration: duration } }
+trace_count = 0
+
+24.times do |index|
+  timestamp = (index * 5).hours.ago
+  calls = pending.filter_map do |name, state|
+    next if state[:remaining].zero?
+    # Roughly two calls per tool per trace, front-loaded toward recent time.
+    take = [ state[:remaining], 2 ].min
+    state[:remaining] -= take
+
+    Array.new(take) do
+      error = if state[:errors].positive?
+        state[:errors] -= 1
+        "#{name.split('__').last} timed out after 30s"
+      end
+      { name: name, duration: state[:duration], args: SAMPLE_ARGS[name], error: error }
+    end
+  end.flatten
+
+  next if calls.empty? && index.positive?
+
+  build_trace(
+    account: account,
+    agent_class: index.even? ? "SupportAgent" : "ResearchAgent",
+    calls: calls,
+    timestamp: timestamp,
+    declared: DECLARED
+  )
+  trace_count += 1
+end
+
+# solid_agent side: a context whose generations carry the offered roster in
+# provenance and the tool calls the model made, plus the tool results.
+context = AgentContext.create!(
+  agent_name: "SupportAgent",
+  action_name: "respond",
+  contextable: agent,
+  instructions: "You are a support agent."
+)
+context.add_user_message("Where is my order ORD-4417?")
+context.generations.create!(
+  model: "claude-sonnet-5",
+  provider: "anthropic",
+  finish_reason: "tool_calls",
+  input_tokens: 820,
+  output_tokens: 240,
+  duration_seconds: 1.4,
+  tool_calls: [
+    { "name" => "lookup_order", "arguments" => { "order_id" => "ORD-4417" } },
+    { "name" => "mcp__github__create_issue", "arguments" => { "title" => "Order lookup flaky" } }
+  ],
+  provenance: {
+    "agent_class" => "SupportAgent",
+    "tools" => DECLARED + [
+      { "name" => "refund_order", "description" => "Issue a refund for an order.", "parameters" => [ "order_id", "amount" ] }
+    ]
+  }
+)
+context.add_tool_message(tool_call_id: SecureRandom.hex(4), tool_name: "lookup_order", result: "Shipped 2 days ago", arguments: { "order_id" => "ORD-4417" })
+context.add_tool_message(tool_call_id: SecureRandom.hex(4), tool_name: "mcp__github__create_issue", result: "opened #412", arguments: { "title" => "Order lookup flaky" })
+
+# One agent declares MCP servers it has not called yet, so the "configured"
+# status has a representative in the view.
+agent&.update!(mcp_servers: [ "filesystem", "sequential-thinking" ], tools: Array(agent.tools) | [ "search", "memory" ])
+
+inventory = ActionAgent::ToolDiscovery.new(
+  traces: TelemetryTrace.for_account(account),
+  agents: ActionAgent.agents_for(account),
+  hours: 24 * 7
+).inventory
+puts "  traces:  #{trace_count}"
+puts "  tools:   #{inventory[:tools].size} (#{inventory[:summary][:active_tools]} active, #{inventory[:summary][:unused_tools]} unused)"
+puts "  servers: #{inventory[:servers].count { |s| s[:status] == 'active' }} active / #{inventory[:servers].size} listed"
+puts "  calls:   #{inventory[:summary][:total_calls]}"

--- a/test/controllers/api/mcp_servers_controller_test.rb
+++ b/test/controllers/api/mcp_servers_controller_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The engine's Tools and MCP Services endpoints, exercised through this
+# app's mount at /dashboard.
+#
+# The engine's own suite covers the single-user shape its dummy app has.
+# These cover what only a multi-tenant host can reach: traffic scoped to an
+# account, and a launched sandbox belonging to the user who opened it rather
+# than to the tenant that `current_owner` resolves to.
+class Api::McpServersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create_user
+    @account = create_account(owner: @user)
+    sign_in_as(@user)
+  end
+
+  def create_trace(tool_names, account: @account, agent_class: "SupportAgent")
+    spans = [
+      {
+        "span_id" => "r1", "parent_span_id" => nil, "name" => "#{agent_class}.respond",
+        "type" => "root", "duration_ms" => 900.0, "status" => "OK",
+        "attributes" => { "agent.class" => agent_class, "agent.action" => "respond" }
+      }
+    ]
+    Array(tool_names).each_with_index do |name, index|
+      spans << {
+        "span_id" => "t#{index}", "parent_span_id" => "r1", "name" => "tool.#{name}",
+        "type" => "tool", "duration_ms" => 50.0, "status" => "OK",
+        "attributes" => { "tool.name" => name }
+      }
+    end
+
+    TelemetryTrace.create_from_payload(
+      {
+        "trace_id" => SecureRandom.hex(16), "service_name" => "app",
+        "environment" => "production", "timestamp" => Time.current.iso8601(6), "spans" => spans
+      },
+      {},
+      account: account
+    )
+  end
+
+  test "tools are scoped to the signed-in account" do
+    create_trace([ "mcp__playwright__browser_navigate" ])
+    create_trace([ "someone_elses_tool" ], account: create_account(owner: create_user))
+
+    get "/dashboard/api/tools"
+
+    assert_response :success
+    names = json_response["tools"].map { |tool| tool["name"] }
+    assert_includes names, "mcp__playwright__browser_navigate"
+    assert_not_includes names, "someone_elses_tool"
+  end
+
+  test "MCP services list detected servers alongside the default catalog" do
+    create_trace([ "mcp__playwright__browser_navigate" ])
+
+    get "/dashboard/api/mcp_servers"
+
+    assert_response :success
+    servers = json_response["servers"].index_by { |server| server["key"] }
+    assert_equal "active", servers["playwright"]["status"]
+    assert_equal "available", servers["fetch"]["status"]
+  end
+
+  test "a launched sandbox belongs to the user who opened it" do
+    assert_difference -> { SandboxSession.count }, 1 do
+      post "/dashboard/api/mcp_servers/playwright/launch"
+    end
+
+    assert_response :created
+
+    sandbox = SandboxSession.order(:created_at).last
+    # SandboxSession prefers :user, but current_owner is the account in a
+    # multi-tenant install — assigning through the ownership seam would put
+    # an Account in the user association and raise.
+    assert_equal @user, sandbox.user
+    assert_equal @account, sandbox.account
+    assert_equal [ "playwright" ], sandbox.mcp_servers
+  end
+
+  test "a launched sandbox is listed as running for its owner only" do
+    post "/dashboard/api/mcp_servers/filesystem/launch"
+    assert_response :created
+
+    get "/dashboard/api/mcp_servers"
+    assert_equal [ [ "filesystem" ] ], json_response["sandboxes"].map { |s| s["mcp_servers"] }
+
+    delete "/session"
+    sign_in_as(create_user_with_account)
+    get "/dashboard/api/mcp_servers"
+    assert_empty json_response["sandboxes"]
+  end
+
+  test "servers needing host credentials are listed but not launchable" do
+    assert_no_difference -> { SandboxSession.count } do
+      post "/dashboard/api/mcp_servers/github/launch"
+    end
+
+    assert_response :unprocessable_entity
+    assert_match(/GITHUB_TOKEN/, json_response["reason"])
+  end
+
+  private
+
+  def create_user_with_account
+    user = create_user
+    create_account(owner: user)
+    user
+  end
+end


### PR DESCRIPTION
## Why

The dashboard's new MCP Services view (activeagents/activeagent#355) can start a catalog server inside a sandbox, and records which ones a session was launched with so a running server reads as running instead of offering to start a second copy.

The engine's install generator creates that column with the table. Our `sandbox_sessions` predates the engine, so it needs the column added here — this is the host-side half of that feature, and the whole of it in this repo.

**Stacked on #102**, which is what mounts the engine at all. The Gemfile follows the engine branch carrying the views; flip both to `main` as the stack lands.

## What the migration does

Two additive columns, both defaulted:

- **`mcp_servers`** (jsonb, GIN-indexed) — the servers a session was launched with. Containment is how the engine looks a server up across sessions.
- **`account_id`** — `SandboxSession` declares `owned_by :user, :account`, and the engine's own schema carries both columns so a deployment's ownership shape stays a configuration change rather than a migration. Ours had only `user_id` — the one that actually scopes sandboxes here — so the model could not answer the same question every other dashboard model does. #102's owner-columns migration covered agents, keys and recordings; this is the gap it left.

Sessions created before this read as "no MCP servers" rather than nil.

## Testing

**291 runs, 0 failures** — #102's 286 plus five here.

The new tests exercise the engine's endpoints through our mount at `/dashboard`, covering what only a multi-tenant host can reach and the engine's own suite (a single-user dummy app) cannot:

- tool traffic scoped to the signed-in account, not leaking across accounts
- detected servers listed alongside the default catalog
- **a launched sandbox belonging to the user who opened it**, not to the account `current_owner` resolves to
- a running sandbox listed for its owner only
- servers needing host credentials listed but refused a launch

That third one is a real bug the browser caught against this app: `SandboxSession` prefers `:user`, but `current_owner` is the account in multi-tenant mode, so assigning through the ownership seam raised `AssociationTypeMismatch` on every launch. Fixed engine-side in #355; the regression test lives here because this is the only place multi-tenancy exists.

Also verified end to end in Chromium: sign in → `/dashboard/tools` and `/dashboard/mcp` render with the engine's fingerprinted assets, `/dashboard/api/tools` returns the inventory, and a Playwright sandbox launches and reports as running.

## Review notes

- **`solid_agent` stays pinned at 0.1.1.** A plain `bundle update` carries it to 0.2.0, whose tool-cache key change fails `AgentToolboxTest` — the upgrade #102 deliberately deferred. I hit exactly that and pinned back; `--conservative` is what keeps it put.
- One consequence: the engine reads an offered tool roster from `provenance["tools"]`, which solid_agent only writes as of activeagents/solid_agent#5. That detection source is inert here until the pin moves; the other three cover the feature meanwhile.
- `script/seed_tool_inventory.rb` is development-only — it writes the traces, contexts, generations and tool messages a real run would, so the mounted views have something to render locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoEMwqrTweQW7rSuiJLqSG)_