### PR TITLE
Bump brakeman 8.0.5 → 8.0.6 to unblock scan_ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.22.0)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     cgi (0.5.1)


### PR DESCRIPTION
## Why

`scan_ruby` is failing on `main` and on every open pull request:

```
Run bin/brakeman --no-pager
Brakeman 8.0.5 is not the latest version 8.0.6
Error: Process completed with exit code 5.
```

`bin/brakeman` prepends `--ensure-latest`:

```ruby
ARGV.unshift("--ensure-latest")
```

so brakeman exits 5 whenever a newer release exists on RubyGems than the one in `Gemfile.lock` — **independent of the diff being scanned**. 8.0.6 shipped, the lock pinned 8.0.5, and every branch went red at the same moment. Nothing in any of the affected PRs caused it.

## What this changes

One line:

```diff
-    brakeman (8.0.5)
+    brakeman (8.0.6)
```

`bundle update --conservative brakeman` kept it to the brakeman entry alone — no other gem moved.

## Verification

Ran the exact CI invocation locally on this branch:

```
$ bin/brakeman --no-pager
Brakeman Version: 8.0.6
Controllers: 36   Models: 31   Templates: 41
Errors: 0
Security Warnings: 0
No warnings found
exit 0
```

So the bump both clears the version gate and leaves the scan itself clean — 8.0.6 introduces no new findings against this codebase.

## This will recur

The next brakeman release turns `scan_ruby` red again, on `main` and on every open PR, for reasons unrelated to any change under review. It has already happened at least once before (noted in the review of #102).

Two mechanisms are available, and they are not mutually exclusive:

- **Dependabot already tracks bundler daily** (`.github/dependabot.yml`), so it will open the brakeman bump as a normal reviewable PR without CI having to fail first.
- **Dropping `ARGV.unshift("--ensure-latest")` from `bin/brakeman`** would stop a third-party release from gating unrelated work. The scan still runs on every PR; it just no longer demands being the newest published version.

I deliberately did **not** make that second change here: `--ensure-latest` is the Rails-generated default for `bin/brakeman`, so removing it is a security-posture call for the maintainers rather than part of a CI unblock. Happy to send it as a one-line follow-up if you want it.

## Related

Unblocks the `scan_ruby` check on #117, #118, #119, #120 and #121, which are all currently red for this reason alone (their `lint` checks pass). The same one-line bump has been ported into each of those branches so they can go green before this merges; those ports become no-ops once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_0157vWB31zDjEX1mCCMDE4W3)_