### PR TITLE
Dashboard review follow-ups: recording write auth, param coercion, template detail, Interactions guards

### DIFF
--- a/app/controllers/api/agent_runs_controller.rb
+++ b/app/controllers/api/agent_runs_controller.rb
@@ -32,8 +32,8 @@ module Api
       scope = scope.where(agent_id: params[:agent_id]) if params[:agent_id].present?
       scope = scope.where(status: params[:status]) if params[:status].present?
 
-      page = (params[:page] || 1).to_i
-      per_page = (params[:per_page] || 20).to_i
+      page = clamped_param(:page, default: 1, min: 1, max: 1_000_000)
+      per_page = clamped_param(:per_page, default: 20, min: 1, max: 100)
       total = scope.count
       runs = scope.offset((page - 1) * per_page).limit(per_page)
 

--- a/app/controllers/api/agents_controller.rb
+++ b/app/controllers/api/agents_controller.rb
@@ -109,9 +109,9 @@ module Api
     # observed from telemetry have no AgentRun rows at all, so a runs-only
     # list showed them as empty while their scorecard reported real traffic.
     def runs
-      minutes = params[:minutes].presence&.then { |m| m.to_i.clamp(1, 60 * 24 * 90) }
-      page = (params[:page] || 1).to_i
-      per_page = (params[:per_page] || 20).to_i
+      minutes = integer_param(:minutes)&.clamp(1, 60 * 24 * 90)
+      page = clamped_param(:page, default: 1, min: 1, max: 1_000_000)
+      per_page = clamped_param(:per_page, default: 20, min: 1, max: 100)
 
       executions = AgentExecutions.new(
         agents: [ @agent ],
@@ -194,7 +194,7 @@ module Api
 
     # GET /api/agents/:id/analytics
     def analytics
-      days = (params[:days] || 30).to_i
+      days = integer_param(:days, default: 30)
       start_date = days.days.ago.beginning_of_day
 
       runs = @agent.agent_runs.where("created_at >= ?", start_date)

--- a/app/controllers/api/agents_controller.rb
+++ b/app/controllers/api/agents_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class AgentsController < BaseController
+    include AgentSerialization
+
     # Ranking for the agent cards. Every dimension except "recent" reads the
     # scorecard, which is computed in Ruby over both execution sources, so
     # the ordering is applied there rather than in the SQL scope.
@@ -330,39 +332,6 @@ module Api
         model_config: {},
         response_format: {}
       )
-    end
-
-    def agent_json(agent, include_details: false)
-      json = {
-        id: agent.id,
-        name: agent.name,
-        slug: agent.slug,
-        description: agent.description,
-        provider: agent.provider,
-        model: agent.model,
-        status: agent.status,
-        preset_type: agent.preset_type,
-        appearance: agent.appearance,
-        version_count: agent.version_count,
-        created_at: agent.created_at,
-        updated_at: agent.updated_at
-      }
-
-      if include_details
-        json.merge!(
-          instructions: agent.instructions,
-          action_prompts: agent.action_prompts,
-          instruction_sets: agent.instruction_sets,
-          tools: agent.tools,
-          mcp_servers: agent.mcp_servers,
-          model_config: agent.model_config,
-          response_format: agent.response_format,
-          agent_class_name: agent.agent_class_name,
-          telemetry_agent_class: agent.telemetry_agent_class
-        )
-      end
-
-      json
     end
 
     def version_json(version, include_diff: false)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -25,15 +25,19 @@ module Api
     # Reads an integer from params, falling back to `default` when the value
     # is absent or blank. Non-numeric input becomes 0 via to_i.
     #
-    # The value is coerced through `to_s` first because a param can arrive
-    # as a container rather than a scalar (`page[]=1&page[]=2` from a query
-    # string, or a JSON object in the body). Array and
+    # A param can arrive as a container rather than a scalar (`page[]=1&page[]=2`
+    # from a query string, or a JSON object in the body). Array and
     # ActionController::Parameters do not respond to `to_i`, so reading them
     # directly raised NoMethodError and returned a 500 where a default or a
-    # clamped value was intended.
+    # clamped value was intended. A multi-valued param means its first value
+    # (Array#to_s would concatenate them, turning [1, 2] into 12); a nested
+    # object is malformed and becomes 0 like any other non-numeric input.
     def integer_param(name, default: nil)
       raw = params[name]
-      raw.presence ? raw.to_s.to_i : default
+      raw = raw.first if raw.is_a?(Array)
+      return default if raw.blank?
+
+      raw.to_s.to_i
     end
 
     # integer_param, then clamped into [min, max]. Non-numeric input becomes

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -22,6 +22,26 @@ module Api
       render json: { error: "No account" }, status: :unauthorized if current_account.nil?
     end
 
+    # Reads an integer from params, falling back to `default` when the value
+    # is absent or blank. Non-numeric input becomes 0 via to_i.
+    #
+    # The value is coerced through `to_s` first because a param can arrive
+    # as a container rather than a scalar (`page[]=1&page[]=2` from a query
+    # string, or a JSON object in the body). Array and
+    # ActionController::Parameters do not respond to `to_i`, so reading them
+    # directly raised NoMethodError and returned a 500 where a default or a
+    # clamped value was intended.
+    def integer_param(name, default: nil)
+      raw = params[name]
+      raw.presence ? raw.to_s.to_i : default
+    end
+
+    # integer_param, then clamped into [min, max]. Non-numeric input becomes
+    # 0 and is then clamped up to `min`.
+    def clamped_param(name, default:, min:, max:)
+      integer_param(name, default: default).clamp(min, max)
+    end
+
     def not_found
       render json: { error: "Record not found" }, status: :not_found
     end

--- a/app/controllers/api/benchmarks_controller.rb
+++ b/app/controllers/api/benchmarks_controller.rb
@@ -103,7 +103,14 @@ module Api
         render json: { ok: true, status: "queued", message: "Benchmark queued for async execution" }
       end
     rescue => e
-      render json: { error: e.message, backtrace: e.backtrace.first(5) }, status: :internal_server_error
+      # The exception is logged in full server-side; the response carries
+      # only a generic message. Backtrace frames expose absolute filesystem
+      # paths, gem versions and internal structure, none of which a client
+      # needs to learn that a benchmark failed.
+      Rails.logger.error(
+        "[Benchmarks] run failed: #{e.class}: #{e.message}\n#{e.backtrace&.first(20)&.join("\n")}"
+      )
+      render json: { error: "Benchmark run failed" }, status: :internal_server_error
     end
 
     # POST /api/benchmarks

--- a/app/controllers/api/benchmarks_controller.rb
+++ b/app/controllers/api/benchmarks_controller.rb
@@ -141,21 +141,6 @@ module Api
       render json: { error: "Authentication required" }, status: :unauthorized
     end
 
-    # Reads an integer knob from params, falling back to `default` when absent
-    # and clamping whatever arrives into [min, max]. Non-numeric input becomes
-    # 0 via to_i and is then clamped up to `min`.
-    #
-    # The value is coerced through `to_s` first because a knob can arrive as a
-    # container rather than a scalar (`requests[]=1&requests[]=2`, or a JSON
-    # object): Array and ActionController::Parameters do not respond to `to_i`,
-    # so reading them directly raised NoMethodError and returned a 500 instead
-    # of the documented clamp.
-    def clamped_param(name, default:, min:, max:)
-      raw = params[name]
-      value = raw.presence ? raw.to_s.to_i : default
-      value.clamp(min, max)
-    end
-
     def parse_payload
       body = request.body.read
       return nil if body.blank?

--- a/app/controllers/api/interactions_controller.rb
+++ b/app/controllers/api/interactions_controller.rb
@@ -33,12 +33,15 @@ module Api
         .order("agent_context_id, created_at DESC")
         .to_h { |generation| [ generation.agent_context_id, generation.model ] }
 
+      previews = message_previews(contexts.map(&:id))
+
       persisted = contexts.map do |context|
         serialize_context(context).merge(
           source: "platform",
           model: latest_models[context.id],
           message_count: message_counts[context.id] || 0,
-          generation_count: generation_counts[context.id] || 0
+          generation_count: generation_counts[context.id] || 0,
+          preview: previews[context.id] || { input: nil, output: nil }
         )
       end
 
@@ -69,6 +72,36 @@ module Api
     end
 
     private
+
+    # What each stream opened with and what it finally answered, so a
+    # collapsed interaction row says what it was about — the same two lines a
+    # collapsed trace row shows. Two grouped queries rather than loading
+    # every message: the list is fifty streams deep and only needs the ends
+    # of each.
+    def message_previews(context_ids)
+      return {} if context_ids.empty?
+
+      first_input = edge_messages(context_ids, "user", :minimum)
+      last_output = edge_messages(context_ids, "assistant", :maximum)
+
+      context_ids.index_with do |id|
+        {
+          input: InteractionPreview.line(first_input[id]),
+          output: InteractionPreview.line(last_output[id])
+        }
+      end
+    end
+
+    # The first or last message of a role per context. Messages are only ever
+    # appended, so the smallest and largest ids are the ends of the stream.
+    def edge_messages(context_ids, role, edge)
+      scope = AgentMessage
+        .where(agent_context_id: context_ids, role: role)
+        .where.not(content: [ nil, "" ])
+
+      ids = scope.group(:agent_context_id).public_send(edge, :id)
+      AgentMessage.where(id: ids.values).pluck(:agent_context_id, :content).to_h
+    end
 
     # Agents executing outside the platform never write solid_agent contexts —
     # they only report traces. Every reported trace is an interaction: one run

--- a/app/controllers/api/interactions_controller.rb
+++ b/app/controllers/api/interactions_controller.rb
@@ -15,7 +15,7 @@ module Api
 
     # GET /api/interactions
     def index
-      limit = params.fetch(:limit, DEFAULT_LIMIT).to_i.clamp(1, 200)
+      limit = clamped_param(:limit, default: DEFAULT_LIMIT, min: 1, max: 200)
 
       contexts = interactions_scope
         .includes(:contextable)
@@ -100,8 +100,7 @@ module Api
     def window_minutes
       return @window_minutes if defined?(@window_minutes)
 
-      raw = params[:minutes].presence
-      @window_minutes = raw ? raw.to_i.clamp(1, MAX_WINDOW_MINUTES) : nil
+      @window_minutes = integer_param(:minutes)&.clamp(1, MAX_WINDOW_MINUTES)
     end
 
     def interactions_scope

--- a/app/controllers/api/metrics_controller.rb
+++ b/app/controllers/api/metrics_controller.rb
@@ -28,7 +28,7 @@ module Api
 
     # GET /api/metrics
     def show
-      hours = params.fetch(:hours, DEFAULT_WINDOW_HOURS).to_i.clamp(1, MAX_WINDOW_HOURS)
+      hours = clamped_param(:hours, default: DEFAULT_WINDOW_HOURS, min: 1, max: MAX_WINDOW_HOURS)
       now = Time.current
 
       current = traces_scope.for_date_range(hours.hours.ago(now), now)

--- a/app/controllers/api/session_recordings_controller.rb
+++ b/app/controllers/api/session_recordings_controller.rb
@@ -5,7 +5,22 @@ module Api
     # Allow unauthenticated access for user session tracking (lander analytics)
     allow_unauthenticated_access only: [ :start_user_session, :record_action, :complete_session, :demo ]
 
+    # allow_unauthenticated_access skips require_authentication, which is
+    # also the only thing that populates Current.session — so a signed-in
+    # visitor was anonymous on these actions. Identify them without
+    # requiring them, so their recordings carry their account and the
+    # ownership gate below recognises them.
+    before_action :resume_session, only: [ :start_user_session, :record_action, :complete_session ]
+
     before_action :set_recording, only: [ :show, :actions, :snapshot, :export, :handoff ]
+    before_action :set_writable_recording, only: [ :record_action, :complete_session ]
+
+    # The write token start_user_session hands the browser. Anonymous writes
+    # to a recording are accepted only with the token minted for that
+    # recording, so a caller who merely knows (or guesses) an id cannot
+    # append actions to, or force-complete, someone else's live session.
+    WRITE_TOKEN_PURPOSE = :session_recording_write
+    WRITE_TOKEN_TTL = 24.hours
 
     # Browser state that must never leave the server in a read/export response.
     SENSITIVE_STATE_KEYS = %w[cookies session_storage local_storage].freeze
@@ -172,13 +187,19 @@ module Api
         page_url: params[:page_url]
       )
 
-      # Set user agent from request
-      recording.update!(
-        metadata: recording.metadata.merge(
-          user_agent: request.user_agent,
-          ip_hash: Digest::SHA256.hexdigest(request.remote_ip.to_s)[0..16]
-        )
-      )
+      # Set user agent from request. A signed-in visitor's recording is
+      # stamped with their account, the same key #index and
+      # can_manage_recording? resolve ownership through.
+      # String keys: the stored metadata is string-keyed, and merging symbols
+      # into it wrote a second "user_agent" that json 3.0 refuses to encode.
+      request_metadata = {
+        "user_agent" => request.user_agent,
+        "ip_hash" => Digest::SHA256.hexdigest(request.remote_ip.to_s)[0..16]
+      }
+      if (account = current_user&.primary_account)
+        request_metadata["account_id"] = account.id.to_s
+      end
+      recording.update!(metadata: recording.metadata.merge(request_metadata))
 
       # Record the handoff action
       recording.record_action!(
@@ -193,6 +214,7 @@ module Api
       render json: {
         recording_id: recording.id,
         visitor_id: recording.metadata["visitor_id"],
+        recording_token: write_token_for(recording),
         message: "User session started"
       }, status: :created
     end
@@ -200,7 +222,7 @@ module Api
     # POST /api/session_recordings/:id/record_action
     # Record a user action in an active session
     def record_action
-      recording = SessionRecording.find(params[:id])
+      recording = @recording
 
       unless recording.recording?
         render json: { error: "Recording already completed" }, status: :unprocessable_entity
@@ -224,7 +246,7 @@ module Api
     # POST /api/session_recordings/:id/complete
     # Complete a user session recording
     def complete_session
-      recording = SessionRecording.find(params[:id])
+      recording = @recording
 
       unless recording.recording?
         render json: { error: "Recording already completed" }, status: :unprocessable_entity
@@ -320,6 +342,40 @@ module Api
       PUBLIC_DEMO_ACTIONS.include?(action_name) && @recording.name == "lander_demo"
     end
 
+    # The write side of the gate. A recording may be written by whoever may
+    # manage it (its account, or an admin) or by the anonymous browser that
+    # started it, which proves that with the token start_user_session issued.
+    #
+    # Not found and not writable answer identically (404), so a real id
+    # cannot be told from a bogus one by probing: the previous shape answered
+    # 422 "already completed" for any real id and 404 for the rest, which was
+    # an oracle over the id space.
+    def set_writable_recording
+      @recording = SessionRecording.find_by(id: params[:id])
+      return not_found if @recording.nil?
+      return if can_manage_recording?(@recording)
+      return if write_token_valid?(@recording)
+
+      not_found
+    end
+
+    def write_token_for(recording)
+      write_token_verifier.generate(recording.id, purpose: WRITE_TOKEN_PURPOSE, expires_in: WRITE_TOKEN_TTL)
+    end
+
+    # Accepted in the JSON body (the lander's fetch calls) or as a header, so
+    # a client that cannot add a body field still has a way in.
+    def write_token_valid?(recording)
+      token = params[:recording_token].presence || request.headers["X-Recording-Token"].presence
+      return false unless token.is_a?(String)
+
+      write_token_verifier.verified(token, purpose: WRITE_TOKEN_PURPOSE) == recording.id
+    end
+
+    def write_token_verifier
+      Rails.application.message_verifier(WRITE_TOKEN_PURPOSE)
+    end
+
     # The continuation records the caller's own session, so stamp it with the
     # caller's account the same way can_manage_recording? resolves ownership.
     # Without it a continuation inherits no owner at all whenever the parent has
@@ -348,9 +404,11 @@ module Api
         return true if recording.metadata["account_id"].to_s == account_id
       end
 
-      # Check sandbox session ownership
-      if recording.sandbox_session&.respond_to?(:user_id)
-        return true if recording.sandbox_session.user_id == current_user&.id
+      # Check sandbox session ownership. Only for a signed-in caller: with
+      # no user, a sandbox that has no user_id would otherwise compare
+      # nil == nil and hand the recording to anyone.
+      if current_user && recording.sandbox_session&.respond_to?(:user_id)
+        return true if recording.sandbox_session.user_id == current_user.id
       end
 
       false

--- a/app/controllers/api/session_recordings_controller.rb
+++ b/app/controllers/api/session_recordings_controller.rb
@@ -44,8 +44,8 @@ module Api
       end
 
       # Pagination
-      page = (params[:page] || 1).to_i
-      per_page = [ (params[:per_page] || 20).to_i, 100 ].min
+      page = clamped_param(:page, default: 1, min: 1, max: 1_000_000)
+      per_page = clamped_param(:per_page, default: 20, min: 1, max: 100)
       offset = (page - 1) * per_page
 
       total = recordings.count
@@ -115,11 +115,11 @@ module Api
       actions = @recording.recording_actions.ordered
 
       # Support pagination for large recordings
-      if params[:after_sequence].present?
-        actions = actions.where("sequence > ?", params[:after_sequence].to_i)
+      if (after_sequence = integer_param(:after_sequence))
+        actions = actions.where("sequence > ?", after_sequence)
       end
 
-      limit = [ params[:limit]&.to_i || 100, 500 ].min
+      limit = clamped_param(:limit, default: 100, min: 1, max: 500)
       actions = actions.limit(limit)
 
       render json: {

--- a/app/controllers/api/templates_controller.rb
+++ b/app/controllers/api/templates_controller.rb
@@ -2,6 +2,8 @@
 
 module Api
   class TemplatesController < BaseController
+    include AgentSerialization
+
     # No anonymous exemption: #show looks a template up by bare id, so the
     # exemption served unpublished drafts and private prompt libraries to
     # anyone walking the id space. #index was already limited to public
@@ -38,8 +40,12 @@ module Api
         name: params[:name] || @template.name
       )
 
+      # The detail shape, not a summary: the dashboard opens the new agent in
+      # the editor straight from this response. Seeded from a summary, the
+      # editor showed the agent as unconfigured and its first Save persisted
+      # empty instructions/tools/model_config over the template's real ones.
       if agent.persisted?
-        render json: { agent: agent_json(agent) }, status: :created
+        render json: { agent: agent_json(agent, include_details: true) }, status: :created
       else
         render json: { errors: agent.errors.full_messages }, status: :unprocessable_entity
       end
@@ -73,20 +79,6 @@ module Api
       end
 
       json
-    end
-
-    def agent_json(agent)
-      {
-        id: agent.id,
-        name: agent.name,
-        slug: agent.slug,
-        description: agent.description,
-        provider: agent.provider,
-        model: agent.model,
-        status: agent.status,
-        preset_type: agent.preset_type,
-        appearance: agent.appearance
-      }
     end
   end
 end

--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -15,7 +15,7 @@ module Api
 
     # GET /api/traces
     def index
-      window = params.fetch(:minutes, DEFAULT_WINDOW_MINUTES).to_i.clamp(1, MAX_WINDOW_MINUTES)
+      window = clamped_param(:minutes, default: DEFAULT_WINDOW_MINUTES, min: 1, max: MAX_WINDOW_MINUTES)
       window_scope = traces_scope.for_date_range(window.minutes.ago, Time.current)
 
       scope = window_scope
@@ -23,7 +23,7 @@ module Api
       scope = scope.for_service(params[:service]) if params[:service].present?
       scope = scope.with_errors if params[:status] == "error"
 
-      limit = params.fetch(:limit, DEFAULT_LIMIT).to_i.clamp(1, 1000)
+      limit = clamped_param(:limit, default: DEFAULT_LIMIT, min: 1, max: 1000)
       traces = scope.recent.limit(limit)
 
       render json: {

--- a/app/controllers/concerns/api/agent_serialization.rb
+++ b/app/controllers/concerns/api/agent_serialization.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Api
+  # The agent JSON the dashboard reads, shared by every endpoint that hands
+  # an agent to the React app.
+  #
+  # Two shapes: the summary the list renders, and the detail (instructions,
+  # tools, mcp_servers, model_config, ...) the editor initializes from. Any
+  # endpoint that returns an agent the client may go on to *edit* must render
+  # the detail shape: AgentEditor seeds its form from whatever it is given,
+  # and a summary seeds it with empty instructions/tools/config, which the
+  # first Save then persists over the real record.
+  module AgentSerialization
+    extend ActiveSupport::Concern
+
+    private
+
+    def agent_json(agent, include_details: false)
+      json = {
+        id: agent.id,
+        name: agent.name,
+        slug: agent.slug,
+        description: agent.description,
+        provider: agent.provider,
+        model: agent.model,
+        status: agent.status,
+        preset_type: agent.preset_type,
+        appearance: agent.appearance,
+        version_count: agent.version_count,
+        created_at: agent.created_at,
+        updated_at: agent.updated_at
+      }
+
+      if include_details
+        json.merge!(
+          instructions: agent.instructions,
+          action_prompts: agent.action_prompts,
+          instruction_sets: agent.instruction_sets,
+          tools: agent.tools,
+          mcp_servers: agent.mcp_servers,
+          model_config: agent.model_config,
+          response_format: agent.response_format,
+          agent_class_name: agent.agent_class_name,
+          telemetry_agent_class: agent.telemetry_agent_class
+        )
+      end
+
+      json
+    end
+  end
+end

--- a/app/javascript/components/dashboard/AgentAnalytics.jsx
+++ b/app/javascript/components/dashboard/AgentAnalytics.jsx
@@ -6,6 +6,11 @@ import TimeWindowSelector from './TimeWindowSelector';
 import TracesView from './TracesView';
 import InteractionsView from './InteractionsView';
 
+// A date-only string ("2026-08-26") parses as UTC midnight, which
+// toLocaleDateString then shifts back a day for every viewer west of UTC.
+// Parsing it as local midnight labels the bar with the day it is.
+const localDay = (date) => new Date(`${date}T00:00:00`);
+
 const TABS = [
   { id: 'overview', label: 'Overview' },
   { id: 'traces', label: 'Traces' },
@@ -240,7 +245,7 @@ export default function AgentAnalytics({ agent, onBack, embedded = false }) {
                     </div>
                     {(i === 0 || i === analytics.runs_by_day.length - 1 || analytics.runs_by_day.length <= 7) && (
                       <span className="text-xs mt-2 transform -rotate-45 origin-left" style={{ color: colors.textMuted }}>
-                        {new Date(day.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                        {localDay(day.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                       </span>
                     )}
                   </div>

--- a/app/javascript/components/dashboard/AgentRunner.jsx
+++ b/app/javascript/components/dashboard/AgentRunner.jsx
@@ -179,6 +179,23 @@ export default function AgentRunner({ agent, onBack }) {
     return `${(ms / 1000).toFixed(2)}s`;
   };
 
+  // The Recent Runs rows are list summaries (input/output previews, no
+  // output, error_message or logs), while the Output panel reads the detail
+  // shape — so a clicked historical run showed "No output" and hid its
+  // error. Show the summary at once, then replace it with the detail.
+  const openRun = async (run) => {
+    setCurrentRun({ ...run, output: run.output ?? run.output_preview, error_message: run.error_message ?? run.error });
+    try {
+      const response = await fetch(`/api/runs/${run.id}`);
+      if (response.ok) {
+        const data = await response.json();
+        setCurrentRun(data.run);
+      }
+    } catch (err) {
+      console.error('Failed to load run details:', err);
+    }
+  };
+
   const handleUpgrade = async () => {
     setIsUpgrading(true);
     setUpgradeError(null);
@@ -496,7 +513,7 @@ export default function AgentRunner({ agent, onBack }) {
                   <div
                     key={run.id}
                     className="px-4 py-3 hover:bg-gray-50 cursor-pointer"
-                    onClick={() => setCurrentRun(run)}
+                    onClick={() => openRun(run)}
                   >
                     <div className="flex items-center justify-between mb-1">
                       <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${getStatusColor(run.status)}`}>

--- a/app/javascript/components/dashboard/DashboardAnalytics.jsx
+++ b/app/javascript/components/dashboard/DashboardAnalytics.jsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react';
 
+// A date-only string ("2026-08-26") parses as UTC midnight, which
+// toLocaleDateString then shifts back a day for every viewer west of UTC.
+// Parsing it as local midnight labels the bar with the day it is.
+const localDay = (date) => new Date(`${date}T00:00:00`);
+
 const PERIOD_OPTIONS = [
   { value: 7, label: '7 days' },
   { value: 14, label: '14 days' },
@@ -135,8 +140,8 @@ export default function DashboardAnalytics({ onSelectAgent }) {
                 ))}
               </div>
               <div className="flex justify-between mt-2 text-xs text-gray-400">
-                <span>{analytics.charts.runs_by_day[0]?.date && new Date(analytics.charts.runs_by_day[0].date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
-                <span>{analytics.charts.runs_by_day[analytics.charts.runs_by_day.length - 1]?.date && new Date(analytics.charts.runs_by_day[analytics.charts.runs_by_day.length - 1].date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+                <span>{analytics.charts.runs_by_day[0]?.date && localDay(analytics.charts.runs_by_day[0].date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+                <span>{analytics.charts.runs_by_day[analytics.charts.runs_by_day.length - 1]?.date && localDay(analytics.charts.runs_by_day[analytics.charts.runs_by_day.length - 1].date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
               </div>
             </div>
           ) : (
@@ -167,8 +172,8 @@ export default function DashboardAnalytics({ onSelectAgent }) {
                 ))}
               </div>
               <div className="flex justify-between mt-2 text-xs text-gray-400">
-                <span>{analytics.charts.tokens_by_day[0]?.date && new Date(analytics.charts.tokens_by_day[0].date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
-                <span>{analytics.charts.tokens_by_day[analytics.charts.tokens_by_day.length - 1]?.date && new Date(analytics.charts.tokens_by_day[analytics.charts.tokens_by_day.length - 1].date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+                <span>{analytics.charts.tokens_by_day[0]?.date && localDay(analytics.charts.tokens_by_day[0].date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+                <span>{analytics.charts.tokens_by_day[analytics.charts.tokens_by_day.length - 1]?.date && localDay(analytics.charts.tokens_by_day[analytics.charts.tokens_by_day.length - 1].date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
               </div>
             </div>
           ) : (

--- a/app/javascript/components/dashboard/EvaluationsView.jsx
+++ b/app/javascript/components/dashboard/EvaluationsView.jsx
@@ -45,6 +45,7 @@ export default function EvaluationsView({ embedded = false, agentId = null }) {
   const [expandedEval, setExpandedEval] = useState(null);
   const [showForm, setShowForm] = useState(false);
   const [runningId, setRunningId] = useState(null);
+  const [deletingId, setDeletingId] = useState(null);
   const [form, setForm] = useState({
     agent_id: agentId ? String(agentId) : '', name: '', sample_size: 20,
     criteria: RULE_CRITERIA.map((c) => c.key),
@@ -114,8 +115,10 @@ export default function EvaluationsView({ embedded = false, agentId = null }) {
           },
         }),
       });
-      const data = await response.json();
-      if (!response.ok) throw new Error((data.errors || [data.error]).filter(Boolean).join(', ') || 'Failed to create evaluation');
+      // A non-JSON body (an HTML error page, a sign-in redirect) used to
+      // surface as "Unexpected token <" in the form.
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error((data.errors || [data.error]).filter(Boolean).join(', ') || `Failed to create evaluation (HTTP ${response.status})`);
       setShowForm(false);
       setForm({ ...form, name: '' });
       await fetchEvaluations();
@@ -129,14 +132,38 @@ export default function EvaluationsView({ embedded = false, agentId = null }) {
 
   const handleRun = async (id) => {
     setRunningId(id);
+    setLoadError(null);
     try {
-      await fetch(`/api/evaluations/${id}/run`, {
+      const response = await fetch(`/api/evaluations/${id}/run`, {
         method: 'POST',
         headers: { 'X-CSRF-Token': csrfToken() },
       });
+      if (!response.ok) setLoadError(`Run failed (HTTP ${response.status})`);
       await fetchEvaluations();
     } finally {
       setRunningId(null);
+    }
+  };
+
+  // DELETE /api/evaluations/:id has always existed; nothing in the UI called
+  // it, so a mis-created evaluation permanently blocked reuse of its name.
+  const handleDelete = async (evaluation) => {
+    if (!window.confirm(`Delete "${evaluation.name}"? Its runs are deleted with it.`)) return;
+    setDeletingId(evaluation.id);
+    setLoadError(null);
+    try {
+      const response = await fetch(`/api/evaluations/${evaluation.id}`, {
+        method: 'DELETE',
+        headers: { 'X-CSRF-Token': csrfToken() },
+      });
+      if (response.ok || response.status === 404) {
+        setEvaluations((prev) => prev.filter((e) => e.id !== evaluation.id));
+        if (expandedEval === evaluation.id) setExpandedEval(null);
+      } else {
+        setLoadError(`Delete failed (HTTP ${response.status})`);
+      }
+    } finally {
+      setDeletingId(null);
     }
   };
 
@@ -169,8 +196,11 @@ export default function EvaluationsView({ embedded = false, agentId = null }) {
     : evaluations;
 
   const completedRuns = shownEvaluations.map((e) => e.latest_run).filter((r) => r && r.status === 'complete');
-  const avgScore = completedRuns.length
-    ? completedRuns.reduce((sum, r) => sum + (r.average_score || 0), 0) / completedRuns.length
+  // Only runs with a scored average: a comparison run stores per-model
+  // cohorts with no top-level score, so counting it as 0% halved the card.
+  const scoredRuns = completedRuns.filter((r) => r.average_score != null);
+  const avgScore = scoredRuns.length
+    ? scoredRuns.reduce((sum, r) => sum + r.average_score, 0) / scoredRuns.length
     : null;
   const samplesEvaluated = completedRuns.reduce((sum, r) => sum + (r.samples_evaluated || 0), 0);
 
@@ -538,6 +568,14 @@ export default function EvaluationsView({ embedded = false, agentId = null }) {
                         className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50"
                       >
                         {runningId === evaluation.id ? 'Running…' : 'Run again'}
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handleDelete(evaluation); }}
+                        disabled={deletingId === evaluation.id}
+                        className="ml-2 px-3 py-1.5 text-sm text-red-600 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+                        title="Delete this evaluation and its runs"
+                      >
+                        {deletingId === evaluation.id ? 'Deleting…' : 'Delete'}
                       </button>
                     </div>
                   </div>

--- a/app/javascript/components/dashboard/InteractionsView.jsx
+++ b/app/javascript/components/dashboard/InteractionsView.jsx
@@ -519,6 +519,26 @@ export default function InteractionsView({ agentId = null, embedded = false }) {
                   </div>
                 </div>
 
+                {/* What this conversation was about, before you open it —
+                    the same two lines a trace row shows. */}
+                {!isExpanded && (session.preview?.input || session.preview?.output) && (
+                  <div
+                    className="px-4 pb-3 grid gap-0.5 font-mono text-xs cursor-pointer min-w-0"
+                    style={{ color: colors.textSecondary }}
+                    onClick={() => toggleSession(session.id)}
+                  >
+                    {[
+                      { label: 'input', text: session.preview?.input, color: roleBubble('user').color },
+                      { label: 'output', text: session.preview?.output, color: roleBubble('assistant').color },
+                    ].filter((line) => line.text).map((line) => (
+                      <div key={line.label} className="flex gap-2 min-w-0">
+                        <span className="flex-shrink-0 uppercase" style={{ color: line.color, width: '48px' }}>{line.label}</span>
+                        <span className="truncate">{line.text}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
                 {/* Expanded conversation */}
                 {isExpanded && (
                   <div className="border-t p-4 space-y-3" style={{ borderColor: colors.cardBorder, background: colors.innerBg }}>

--- a/app/javascript/components/dashboard/TemplateLibrary.jsx
+++ b/app/javascript/components/dashboard/TemplateLibrary.jsx
@@ -17,6 +17,7 @@ export default function TemplateLibrary({ onUseTemplate, onClose }) {
   const [selectedTemplate, setSelectedTemplate] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState(null);
 
   useEffect(() => {
     loadTemplates();
@@ -41,6 +42,7 @@ export default function TemplateLibrary({ onUseTemplate, onClose }) {
 
   const handleUseTemplate = async (template) => {
     setIsCreating(true);
+    setCreateError(null);
     try {
       const response = await fetch(`/api/templates/${template.id}/use`, {
         method: 'POST',
@@ -51,9 +53,22 @@ export default function TemplateLibrary({ onUseTemplate, onClose }) {
       if (response.ok) {
         const data = await response.json();
         onUseTemplate(data.agent);
+      } else {
+        // A 422 (validation) or an expired session (redirect/401) used to
+        // reset the button silently, as if nothing had been clicked.
+        let message = `Could not create the agent (HTTP ${response.status})`;
+        try {
+          const data = await response.json();
+          const errors = data.errors || data.error;
+          if (errors) message = Array.isArray(errors) ? errors.join(', ') : String(errors);
+        } catch (_) {
+          // Non-JSON body (e.g. a sign-in redirect): keep the status message.
+        }
+        setCreateError(message);
       }
     } catch (error) {
       console.error('Failed to create agent from template:', error);
+      setCreateError('Could not create the agent — check your connection and try again.');
     } finally {
       setIsCreating(false);
     }
@@ -195,6 +210,9 @@ export default function TemplateLibrary({ onUseTemplate, onClose }) {
               >
                 {isCreating ? 'Creating...' : 'Use This Template'}
               </button>
+              {createError && (
+                <p className="mt-2 text-sm text-red-600" role="alert">{createError}</p>
+              )}
             </div>
           )}
         </div>

--- a/app/javascript/controllers/session_replay_controller.js
+++ b/app/javascript/controllers/session_replay_controller.js
@@ -593,6 +593,9 @@ export default class extends Controller {
       if (response.ok) {
         const data = await response.json()
         this.userSessionId = data.recording_id
+        // Proves to record_action/complete that this browser started the
+        // recording; without it anonymous writes to the recording are refused.
+        this.userSessionToken = data.recording_token
         console.log('User session started:', this.userSessionId)
       } else {
         console.error('Failed to start user session:', response.status)
@@ -621,7 +624,8 @@ export default class extends Controller {
           action_type: actionType,
           selector: selector,
           value: value,
-          metadata: metadata
+          metadata: metadata,
+          recording_token: this.userSessionToken
         })
       })
     } catch (error) {
@@ -643,7 +647,8 @@ export default class extends Controller {
         body: JSON.stringify({
           completion_type: completionType,
           email_submitted: emailSubmitted,
-          success: success
+          success: success,
+          recording_token: this.userSessionToken
         })
       })
 

--- a/app/javascript/pages/Dashboard.jsx
+++ b/app/javascript/pages/Dashboard.jsx
@@ -236,11 +236,13 @@ function DashboardContent({ user, initialAgents = [], meta = {}, account = null,
 
   const handleUseTemplate = (agent) => {
     setAgents([agent, ...agents]);
-    setSelectedAgent(agent);
-    setCurrentView('editor');
     setShowTemplateLibrary(false);
     showNotification('Agent created from template!', 'success');
-    window.history.pushState({}, '', `/dashboard/agents/${agent.id}/edit`);
+    // Through navigateTo rather than setSelectedAgent directly: it refetches
+    // the full record whenever it is handed a summary, so the editor never
+    // initializes from a shallow object and wipes the template's
+    // instructions, tools and model_config on the first save.
+    navigateTo('editor', agent);
   };
 
   // Views that edit or run an agent need its detail fields (instructions,

--- a/app/models/agent_template.rb
+++ b/app/models/agent_template.rb
@@ -157,12 +157,17 @@ class AgentTemplate < ApplicationRecord
         appearance: { hat: "fedora", hatAccessory: "theaterMasks", heldItem: "browser" },
         instruction_sets: [],
         tools: %w[playwright],
-        mcp_servers: {
-          playwright: {
+        # An array of server entries, which is the shape agents.mcp_servers
+        # takes everywhere else (the builder's strong params permit an
+        # array). The old top-level Hash was copied onto agents verbatim and
+        # crashed ToolDiscovery for the whole workspace.
+        mcp_servers: [
+          {
+            name: "playwright",
             command: "npx",
             args: [ "-y", "@anthropic/mcp-server-playwright" ]
           }
-        },
+        ],
         model_config: { temperature: 0.2, max_tokens: 4096 },
         instructions: "You are a browser automation assistant using Playwright MCP.\n\nAvailable actions:\n- browser_navigate: Go to a URL\n- browser_snapshot: Get the accessibility tree\n- browser_click: Click on an element\n- browser_type: Type text into an input\n- browser_take_screenshot: Capture the page\n- browser_wait_for: Wait for text or element\n\nGuidelines:\n1. Always take a snapshot first to understand the page\n2. Use element refs from snapshots for interactions\n3. Wait for page loads before taking actions\n4. Handle errors gracefully\n5. Limit yourself to 10 steps maximum\n\nAlways describe what you see and what actions you're taking.",
         icon: "🎭",

--- a/app/serializers/interaction_preview.rb
+++ b/app/serializers/interaction_preview.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# The two lines a collapsed interaction row shows — what the stream was
+# asked, and what it finally answered. Both sources of an interaction produce
+# them: solid_agent contexts (Api::InteractionsController) and reported
+# traces (TraceInteractionSerializer), so a list mixing the two reads the
+# same way either side of the row came from.
+#
+# Mirrors ActionAgent::InteractionPreview in the actionagent engine.
+module InteractionPreview
+  # One line each. The list is fifty streams deep, and the row clips to a
+  # single line anyway — sending the whole conversation to be truncated in
+  # the browser would pay for text nobody reads.
+  LIMIT = 300
+
+  def self.line(value)
+    text = value.to_s.squish
+    return nil if text.blank?
+
+    text.truncate(LIMIT)
+  end
+end

--- a/app/serializers/trace_interaction_serializer.rb
+++ b/app/serializers/trace_interaction_serializer.rb
@@ -44,6 +44,7 @@ class TraceInteractionSerializer
         total: @trace.total_input_tokens.to_i + @trace.total_output_tokens.to_i
       },
       message_count: messages.size,
+      preview: preview,
       # Tool activity is known even when content capture is off, so a run
       # reported without prompts still shows what it did.
       tool_count: tool_spans.size,
@@ -63,6 +64,19 @@ class TraceInteractionSerializer
   end
 
   private
+
+  # What the run was asked and what it answered — the opening prompt and the
+  # final assistant turn, since the middle of a stream is tool traffic.
+  def preview
+    said = ->(role, list) { list.find { |m| m[:role] == role && m[:content].present? }&.[](:content) }
+
+    {
+      input: InteractionPreview.line(said.call("user", messages)),
+      # A tool-calling assistant turn carries no prose, so the last one that
+      # does is the answer.
+      output: InteractionPreview.line(said.call("assistant", messages.reverse))
+    }
+  end
 
   # The generation span. Older traces wrapped a separate `llm` span inside a
   # root; newer ones merge them, since the provider loop *is* the interaction.
@@ -95,9 +109,11 @@ class TraceInteractionSerializer
     raw = any_attribute("prompt.input.messages")
     return [] if raw.blank?
 
-    entries = JSON.parse(raw)
+    # The ingest endpoint stores span attributes verbatim, so a reporter that
+    # sends the array already decoded persists an Array here, not a String.
+    entries = raw.is_a?(String) ? JSON.parse(raw) : raw
     entries.is_a?(Array) ? entries.select { |m| m.is_a?(Hash) && m["content"].present? } : []
-  rescue JSON::ParserError
+  rescue JSON::ParserError, TypeError
     []
   end
 
@@ -208,9 +224,13 @@ class TraceInteractionSerializer
   # so it renders structurally rather than as an escaped string.
   def parsed(value)
     return nil if value.blank?
+    # A reporter can send an attribute already decoded — JSON.parse raises
+    # TypeError rather than ParserError on a Hash or Array, and one such
+    # span would otherwise take down the whole Interactions list.
+    return value unless value.is_a?(String)
 
     JSON.parse(value)
-  rescue JSON::ParserError
+  rescue JSON::ParserError, TypeError
     value
   end
 

--- a/test/controllers/api/agents_controller_test.rb
+++ b/test/controllers/api/agents_controller_test.rb
@@ -375,6 +375,26 @@ class Api::AgentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 5, data["meta"]["total"]
   end
 
+  # A query value can arrive as a container (`minutes[]=1&minutes[]=2`, or
+  # `page[x]=1`), and neither Array nor ActionController::Parameters
+  # responds to `to_i`. Reading them directly raised NoMethodError and
+  # turned a malformed query into a 500 (#126).
+  test "runs coerces container-valued minutes, page and per_page instead of raising" do
+    create_run(agent: @agent)
+
+    get "/api/agents/#{@agent.id}/runs", params: { minutes: [ 1, 2 ], page: { x: 1 }, per_page: [ 5 ] }
+
+    assert_response :success, "container-valued params were not coerced: #{response.body}"
+    assert_equal 1, json_response["runs"].length
+  end
+
+  test "analytics coerces a container-valued days param instead of raising" do
+    get "/api/agents/#{@agent.id}/analytics", params: { days: [ 7, 30 ] }
+
+    assert_response :success, "container-valued days was not coerced: #{response.body}"
+    assert json_response["summary"].key?("total_runs")
+  end
+
   # ===========================================
   # Execute Tests
   # ===========================================

--- a/test/controllers/api/agents_controller_test.rb
+++ b/test/controllers/api/agents_controller_test.rb
@@ -386,6 +386,9 @@ class Api::AgentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success, "container-valued params were not coerced: #{response.body}"
     assert_equal 1, json_response["runs"].length
+    # A multi-valued param means its first value, never the concatenation.
+    assert_equal 5, json_response["meta"]["per_page"]
+    assert_equal 1, json_response["meta"]["page"], "a nested object is malformed and floors to the default page"
   end
 
   test "analytics coerces a container-valued days param instead of raising" do

--- a/test/controllers/api/benchmarks_controller_test.rb
+++ b/test/controllers/api/benchmarks_controller_test.rb
@@ -183,6 +183,32 @@ class Api::BenchmarksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, config["cpu_iterations"]
   end
 
+  # --- error shape ----------------------------------------------------------
+
+  # Backtrace frames carry absolute server paths, gem versions and internal
+  # class structure. The exception is logged server-side; the client gets a
+  # generic message and nothing else (#123).
+  test "run does not return exception details or backtraces to the client" do
+    sign_in_as(@user)
+
+    # minitest 6 ships stubbing in a separate gem, so replace the constructor
+    # by hand for the duration of the request.
+    BenchmarkRunnerService.define_singleton_method(:new) { |**| raise "boom from /srv/app/lib/very_private.rb" }
+    begin
+      post "/api/benchmarks/run",
+        params: { requests: 2, io_ms: 0, cpu_iters: 1, include_ractors: "false" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+    ensure
+      BenchmarkRunnerService.singleton_class.remove_method(:new)
+    end
+
+    assert_response :internal_server_error
+    assert_equal "Benchmark run failed", json_response["error"]
+    assert_nil json_response["backtrace"]
+    assert_not_includes response.body, "very_private"
+    assert_not_includes response.body, "boom"
+  end
+
   # Positive control for the coercion above: ordinary scalars must still be
   # read as numbers and still be clamped, so a coercion that silently zeroed
   # every knob could not pass the two tests above unnoticed.

--- a/test/controllers/api/interaction_preview_test.rb
+++ b/test/controllers/api/interaction_preview_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Collapsed interaction rows in the dashboard carry two lines — what the stream
+# was asked, and what it finally answered — the same pair a collapsed trace row
+# shows. Both sources of an interaction have to produce them, or a list mixing
+# the two reads differently depending on where each row came from. Ported from
+# the actionagent engine's contract test (#111).
+class Api::InteractionPreviewTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create_user
+    @account = create_account(owner: @user)
+    @agent = create_agent(user: @user, name: "Support")
+    sign_in_as(@user)
+  end
+
+  def create_context
+    AgentContext.create!(
+      contextable: @agent,
+      agent_name: "SupportAgent",
+      action_name: "respond",
+      total_input_tokens: 40,
+      total_output_tokens: 60
+    )
+  end
+
+  def interactions
+    get "/api/interactions"
+    assert_response :success
+    json_response["interactions"]
+  end
+
+  test "a context previews its opening prompt and its final answer" do
+    context = create_context
+    context.add_user_message("Where is order 88213?")
+    context.add_assistant_message("Let me look that up.")
+    context.add_user_message("Any update?")
+    context.add_assistant_message("The carrier never scanned it in.")
+
+    preview = interactions.first["preview"]
+
+    # The ends of the stream, not its middle: the turns in between are tool
+    # traffic and follow-ups that a one-line preview can't summarize.
+    assert_equal "Where is order 88213?", preview["input"]
+    assert_equal "The carrier never scanned it in.", preview["output"]
+  end
+
+  test "a tool-calling assistant turn is skipped for the answer" do
+    context = create_context
+    context.add_user_message("Where is order 88213?")
+    context.add_assistant_message("The carrier never scanned it in.")
+    # A turn that only carries a tool call has no prose to show.
+    context.messages.create!(role: "assistant", content: "")
+
+    assert_equal "The carrier never scanned it in.", interactions.first.dig("preview", "output")
+  end
+
+  test "previews are nil when a stream captured no content" do
+    create_context
+
+    preview = interactions.first["preview"]
+
+    assert_nil preview["input"]
+    assert_nil preview["output"]
+  end
+
+  test "each context gets its own preview" do
+    first = create_context
+    first.add_user_message("Where is order 88213?")
+    second = create_context
+    second.add_user_message("Cancel my subscription")
+
+    previews = interactions.to_h { |row| [ row["id"], row.dig("preview", "input") ] }
+
+    assert_equal "Where is order 88213?", previews[first.id]
+    assert_equal "Cancel my subscription", previews[second.id]
+  end
+
+  test "a reported trace previews from its captured span contents" do
+    TelemetryTrace.create_from_payload(reported_payload(
+      "llm.prompt" => "Summarize   the\nrelease notes",
+      "llm.completion" => "Three fixes and one new setting."
+    ), {}, account: @account)
+
+    preview = interactions.find { |row| row["source"] == "telemetry" }["preview"]
+
+    # Whitespace collapses so the line stays one line whatever the prompt did.
+    assert_equal "Summarize the release notes", preview["input"]
+    assert_equal "Three fixes and one new setting.", preview["output"]
+  end
+
+  test "a preview is clipped rather than sending the whole conversation" do
+    context = create_context
+    context.add_user_message("x" * 5_000)
+
+    input = interactions.first.dig("preview", "input")
+
+    # Length includes the omission ActiveSupport appends.
+    assert_equal InteractionPreview::LIMIT, input.length
+    assert input.end_with?("...")
+  end
+
+  # The ingest endpoint stores span attributes verbatim, so a reporter that
+  # sends tool.arguments or prompt.input.messages already decoded persists a
+  # Hash/Array rather than a JSON string. JSON.parse raises TypeError on
+  # those — which the serializer did not rescue — and one such trace 500ed
+  # the whole account's Interactions list and its own detail view (#111).
+  test "index and show survive a trace whose span attributes are already decoded" do
+    trace = TelemetryTrace.create_from_payload(reported_payload(
+      "llm.completion" => "Found it."
+    ).tap { |payload|
+      payload["spans"].first["attributes"]["prompt.input.messages"] = [ { "role" => "user", "content" => "Find order 1" } ]
+      payload["spans"] << {
+        "span_id" => "tool1", "parent_span_id" => "llm1", "name" => "tool.search",
+        "type" => "tool", "duration_ms" => 50.0, "status" => "OK",
+        "start_time" => Time.current.iso8601(6), "end_time" => (Time.current + 0.05).iso8601(6),
+        "attributes" => { "tool.name" => "search", "tool.arguments" => { "q" => "decoded-object" }, "tool.result" => "ok" }
+      }
+    }, {}, account: @account)
+
+    row = interactions.find { |r| r["id"] == "trace-#{trace.id}" }
+    assert row, "the reported trace must be listed rather than 500 the index"
+    assert_equal "Find order 1", row.dig("preview", "input")
+
+    get "/api/interactions/trace-#{trace.id}"
+
+    assert_response :success
+    tool_call = json_response["interaction"]["messages"].find { |m| m["tool_calls"] }
+    assert_equal({ "q" => "decoded-object" }, tool_call["tool_calls"])
+  end
+
+  private
+
+  def reported_payload(llm_attributes)
+    {
+      "trace_id" => SecureRandom.hex(16),
+      "service_name" => "customer-app",
+      "timestamp" => Time.current.iso8601(6),
+      "spans" => [
+        {
+          "span_id" => "root1", "parent_span_id" => nil, "name" => "ReportedAgent.respond",
+          "type" => "root", "duration_ms" => 1000.0, "status" => "OK",
+          "attributes" => { "agent.class" => "ReportedAgent", "agent.action" => "respond" }
+        },
+        {
+          "span_id" => "llm1", "parent_span_id" => "root1", "name" => "llm.generate",
+          "type" => "llm", "duration_ms" => 900.0, "status" => "OK",
+          "attributes" => { "llm.model" => "mock-model" }.merge(llm_attributes)
+        }
+      ]
+    }
+  end
+end

--- a/test/controllers/api/interactions_controller_test.rb
+++ b/test/controllers/api/interactions_controller_test.rb
@@ -49,6 +49,18 @@ class Api::InteractionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 100, interaction.dig("tokens", "total")
   end
 
+  # Array and ActionController::Parameters do not respond to `to_i`, so a
+  # container-valued query (`minutes[]=60`) raised NoMethodError and 500ed
+  # the whole Interactions list (#126).
+  test "index coerces container-valued minutes and limit instead of raising" do
+    create_interaction
+
+    get "/api/interactions", params: { minutes: [ 60, 120 ], limit: { n: 10 } }
+
+    assert_response :success, "container-valued params were not coerced: #{response.body}"
+    assert_equal 1, json_response["interactions"].length
+  end
+
   test "index does not leak other users' interactions" do
     other_user = create_user
     create_account(owner: other_user)

--- a/test/controllers/api/session_recordings_controller_test.rb
+++ b/test/controllers/api/session_recordings_controller_test.rb
@@ -318,6 +318,138 @@ class Api::SessionRecordingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  # ==================================================
+  # Anonymous writes — record_action and complete
+  # must be bound to the session that started the
+  # recording (#125)
+  # ==================================================
+
+  test "record_action refuses an anonymous caller who only knows the id" do
+    assert_no_difference -> { @recording.recording_actions.count } do
+      post "/api/session_recordings/#{@recording.id}/record_action",
+           params: { action_type: "type", selector: "input[name=card]", value: "4111" }.to_json,
+           headers: { "Content-Type" => "application/json" }
+    end
+
+    assert_response :not_found
+  end
+
+  test "complete refuses an anonymous caller who only knows the id" do
+    post "/api/session_recordings/#{@recording.id}/complete",
+         params: { completion_type: "session_end" }.to_json,
+         headers: { "Content-Type" => "application/json" }
+
+    assert_response :not_found
+    assert @recording.reload.recording?, "the recording must not have been force-completed"
+  end
+
+  test "an unknown id and someone else's id answer identically to anonymous writers" do
+    post "/api/session_recordings/#{@recording.id}/record_action", params: { action_type: "click" }
+    real = [ response.status, response.body ]
+
+    post "/api/session_recordings/999999999/record_action", params: { action_type: "click" }
+    bogus = [ response.status, response.body ]
+
+    assert_equal bogus, real, "a real id must not be distinguishable from a bogus one"
+  end
+
+  test "start_user_session issues a token that authorizes writes to that recording only" do
+    post "/api/session_recordings/start_user_session",
+         params: { page_url: "https://example.com/", step: 4 }.to_json,
+         headers: { "Content-Type" => "application/json" }
+    assert_response :created
+    recording_id = json_response["recording_id"]
+    token = json_response["recording_token"]
+    assert token.present?
+
+    post "/api/session_recordings/#{recording_id}/record_action",
+         params: { action_type: "click", selector: "button.cta", recording_token: token }.to_json,
+         headers: { "Content-Type" => "application/json" }
+    assert_response :success
+    assert json_response["action_id"].present?
+
+    # The token names one recording; it opens no other.
+    assert_no_difference -> { @recording.recording_actions.count } do
+      post "/api/session_recordings/#{@recording.id}/record_action",
+           params: { action_type: "click", recording_token: token }.to_json,
+           headers: { "Content-Type" => "application/json" }
+    end
+    assert_response :not_found
+
+    post "/api/session_recordings/#{recording_id}/complete",
+         params: { completion_type: "session_end", recording_token: token }.to_json,
+         headers: { "Content-Type" => "application/json" }
+    assert_response :success
+    assert_equal "completed", json_response["status"]
+  end
+
+  test "the write token is also accepted as a header" do
+    post "/api/session_recordings/start_user_session", params: { page_url: "https://example.com/" }
+    recording_id = json_response["recording_id"]
+    token = json_response["recording_token"]
+
+    post "/api/session_recordings/#{recording_id}/record_action",
+         params: { action_type: "scroll" }, headers: { "X-Recording-Token" => token }
+
+    assert_response :success
+  end
+
+  test "a forged or tampered token does not authorize writes" do
+    post "/api/session_recordings/start_user_session", params: { page_url: "https://example.com/" }
+    recording_id = json_response["recording_id"]
+    token = json_response["recording_token"]
+
+    post "/api/session_recordings/#{recording_id}/record_action",
+         params: { action_type: "click", recording_token: "#{token}x" }
+
+    assert_response :not_found
+  end
+
+  test "the owning account may still write to its recording without a token" do
+    sign_in_as(@owner)
+
+    assert_difference -> { @recording.recording_actions.count }, 1 do
+      post "/api/session_recordings/#{@recording.id}/record_action",
+           params: { action_type: "click", selector: "button.cta" }
+    end
+
+    assert_response :success
+  end
+
+  test "another signed-in account may not write to the recording" do
+    sign_in_as(@intruder)
+
+    assert_no_difference -> { @recording.recording_actions.count } do
+      post "/api/session_recordings/#{@recording.id}/record_action",
+           params: { action_type: "click", selector: "button.cta" }
+    end
+
+    assert_response :not_found
+  end
+
+  test "a token holder still learns when the recording is already complete" do
+    post "/api/session_recordings/start_user_session", params: { page_url: "https://example.com/" }
+    recording_id = json_response["recording_id"]
+    token = json_response["recording_token"]
+    SessionRecording.find(recording_id).complete!
+
+    post "/api/session_recordings/#{recording_id}/record_action",
+         params: { action_type: "click", recording_token: token }
+
+    assert_response :unprocessable_entity
+    assert_equal "Recording already completed", json_response["error"]
+  end
+
+  test "a signed-in visitor's user session is stamped with their account" do
+    sign_in_as(@owner)
+
+    post "/api/session_recordings/start_user_session", params: { page_url: "https://example.com/" }
+
+    assert_response :created
+    recording = SessionRecording.find(json_response["recording_id"])
+    assert_equal @owner_account.id.to_s, recording.metadata["account_id"]
+  end
+
   # ===========================================
   # Redaction — show/export must not leak (#110)
   # ===========================================

--- a/test/controllers/api/session_recordings_controller_test.rb
+++ b/test/controllers/api/session_recordings_controller_test.rb
@@ -103,6 +103,30 @@ class Api::SessionRecordingsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, json_response["actions"].size
   end
 
+  # Array and ActionController::Parameters do not respond to `to_i`, so a
+  # container-valued query (`limit[]=5`) raised NoMethodError and 500ed
+  # before the query was built (#126).
+  test "actions coerces container-valued after_sequence and limit instead of raising" do
+    sign_in_as(@owner)
+
+    get "/api/session_recordings/#{@recording.id}/actions",
+        params: { after_sequence: [ 0 ], limit: { n: 5 } }
+
+    assert_response :success, "container-valued params were not coerced: #{response.body}"
+    assert_equal 1, json_response["actions"].size
+  end
+
+  test "index coerces container-valued page and per_page instead of raising" do
+    sign_in_as(@owner)
+
+    get "/api/session_recordings", params: { page: [ 1 ], per_page: { n: 20 } }
+
+    assert_response :success, "container-valued params were not coerced: #{response.body}"
+    assert_equal 1, json_response["pagination"]["page"]
+    assert_equal 1, json_response["pagination"]["per_page"],
+                 "a non-numeric per_page must clamp up to 1, never divide by zero"
+  end
+
   test "export still returns 200 for the owning account" do
     sign_in_as(@owner)
 

--- a/test/controllers/api/templates_controller_test.rb
+++ b/test/controllers/api/templates_controller_test.rb
@@ -90,6 +90,33 @@ class Api::TemplatesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "My Copy", json_response["agent"]["name"]
   end
 
+  # The dashboard opens the new agent in the editor straight from this
+  # response. A summary (no instructions/tools/model_config) seeded the editor
+  # with empty fields, and its first Save persisted those over the template's
+  # real configuration (#113).
+  test "use returns the full agent detail the editor initializes from" do
+    sign_in_as(@user)
+    template = create_template(
+      name: "Configured",
+      slug: "configured-#{SecureRandom.hex(4)}",
+      tools: %w[terminal code],
+      mcp_servers: [ { "name" => "playwright", "command" => "npx" } ],
+      model_config: { "temperature" => 0.2, "max_tokens" => 4096 }
+    )
+
+    post "/api/templates/#{template.id}/use", params: { name: "From Template" }
+
+    assert_response :created
+    agent = json_response["agent"]
+    assert_equal "You are a helpful assistant.", agent["instructions"]
+    assert_equal %w[terminal code], agent["tools"]
+    assert_equal [ "rails" ], agent["instruction_sets"]
+    assert_equal [ { "name" => "playwright", "command" => "npx" } ], agent["mcp_servers"]
+    assert_equal({ "temperature" => 0.2, "max_tokens" => 4096 }, agent["model_config"])
+    assert agent.key?("action_prompts"), "detail shape must carry action_prompts"
+    assert agent.key?("response_format"), "detail shape must carry response_format"
+  end
+
   private
 
   def create_template(**attrs)


### PR DESCRIPTION
Five of the open dashboard-review issues, one commit each so they can be read (or reverted) independently.

Closes #125, closes #126, closes #123, closes #113, closes #111.

## Commits

**#125 — Bind anonymous session recording writes to the browser that started them** (🟠)
`record_action` and `complete_session` accepted anonymous writes to any in-progress recording by id. `start_user_session` now issues a signed, purpose-scoped write token for the recording it creates; the two write actions accept an anonymous caller only with that token (body field or `X-Recording-Token` header). The recording's account and admins still write without one. Not-found and not-writable both answer 404 with the same body, closing the id oracle. The lander's Stimulus controller stores and sends the token. `resume_session` runs on the anonymous actions so a signed-in visitor's recording is stamped with their account. Also hardens `can_manage_recording?` (a sandbox with no `user_id` compared `nil == nil` for anonymous callers) and switches the metadata merge to string keys (json 3.0 will refuse the duplicate `user_agent` key the symbol merge produced).

**#126 — Coerce integer params through one container-safe helper**
`integer_param`/`clamped_param` on `Api::BaseController`, used at every remaining `params[...].to_i` site: agents `runs`/`analytics`, interactions, session recordings `index`/`actions`, agent_runs, traces and metrics. Page sizes are floored at 1 where a zero divided by it or returned an empty page.

**#123 — Stop returning exception backtraces from benchmarks#run**
Logged in full server-side; the client gets `{"error":"Benchmark run failed"}`.

**#113 — Return the full agent detail from templates#use**
Agent JSON now lives in one `Api::AgentSerialization` concern shared by `AgentsController` and `TemplatesController`; `#use` renders the detail shape, and `Dashboard.handleUseTemplate` goes through `navigateTo` (which refetches shallow agents anyway). `TemplateLibrary` surfaces a non-2xx response instead of silently resetting the button.

**#111 — Interactions: survive decoded span attributes and add the preview contract**
Ports the engine's guards into `TraceInteractionSerializer` (non-String values used as-is, `TypeError` rescued) so one decoded `tool.arguments` no longer 500s the whole list, and ports the engine's `preview: {input, output}` contract (serializer, `InteractionPreview`, `message_previews` edge queries, two preview lines on collapsed rows in `InteractionsView`) with its contract test.

Also closed #122 directly: its fix (`before_action :resume_session` in `Api::SandboxesController`) already landed with #120 and is covered by tests there.

## Verification

- `bin/rails test` (Postgres 16): 391 runs, 0 failures, 5 errors. The 5 errors are all `PagesControllerTest` failing on `The asset 'application.js' was not found`, i.e. the JS bundle was never built in this container; they are unrelated to this diff.
- All touched controller tests: 0 failures (new coverage for every fix: token auth round-trip, header/forged/cross-recording token, id-oracle parity, container-valued params on each endpoint, generic benchmark error body, template detail shape, decoded-attribute regression, preview contract).
- `bin/rubocop` clean on every touched file; the edited JSX/JS parses under esbuild.

## Not included

- #112 and #116 are superseded by #102 (mount the engine).
- #115 (CSRF on the session-authenticated JSON API) is documented as mitigated by `SameSite=Lax`; left for a dedicated hardening PR since it touches every mutating fetch in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJktGUDUo55811GVjruQQg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJktGUDUo55811GVjruQQg)_